### PR TITLE
Adapt GraphQL layer to Sobek paged API

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -16,6 +16,7 @@ public/theme-*.json
 public/deckplan-editor
 
 # Ignore other files
+.claude
 .github
 .husky
 .vscode

--- a/.prettierignore
+++ b/.prettierignore
@@ -17,6 +17,7 @@ public/deckplan-editor
 
 # Ignore other files
 .claude
+.wolf
 .github
 .husky
 .vscode

--- a/e2e-tests/fixtures/vehicle-types-mock.json
+++ b/e2e-tests/fixtures/vehicle-types-mock.json
@@ -1,45 +1,71 @@
 {
   "data": {
-    "vehicleTypes": [
-      {
-        "id": "NMR:VehicleType:1",
-        "name": { "value": "Type Alpha" },
-        "length": 10,
-        "width": 2.5,
-        "height": 3,
-        "deckPlan": {
-          "id": "NMR:DeckPlan:1",
-          "description": "Single deck",
-          "name": { "value": "Plan A" }
+    "vehicleTypes": {
+      "content": [
+        {
+          "id": "NMR:VehicleType:1",
+          "version": 1,
+          "name": { "value": "Type Alpha" },
+          "shortName": null,
+          "transportMode": null,
+          "length": 10,
+          "width": 2.5,
+          "height": 3,
+          "created": null,
+          "changed": null,
+          "changedBy": null,
+          "versionComment": null,
+          "deckPlan": {
+            "id": "NMR:DeckPlan:1",
+            "description": "Single deck",
+            "name": { "value": "Plan A" }
+          },
+          "vehicles": [{ "id": "NMR:Vehicle:101", "registrationNumber": "AA-101", "version": 1 }]
         },
-        "vehicles": [{ "id": "NMR:Vehicle:101", "registrationNumber": "AA-101", "version": 1 }]
-      },
-      {
-        "id": "NMR:VehicleType:2",
-        "name": { "value": "Type Beta" },
-        "length": 15,
-        "width": 2.8,
-        "height": 3.5,
-        "deckPlan": {
-          "id": "NMR:DeckPlan:2",
-          "description": "Double deck",
-          "name": { "value": "Plan B" }
+        {
+          "id": "NMR:VehicleType:2",
+          "version": 1,
+          "name": { "value": "Type Beta" },
+          "shortName": null,
+          "transportMode": null,
+          "length": 15,
+          "width": 2.8,
+          "height": 3.5,
+          "created": null,
+          "changed": null,
+          "changedBy": null,
+          "versionComment": null,
+          "deckPlan": {
+            "id": "NMR:DeckPlan:2",
+            "description": "Double deck",
+            "name": { "value": "Plan B" }
+          },
+          "vehicles": [{ "id": "NMR:Vehicle:102", "registrationNumber": "BB-102", "version": 1 }]
         },
-        "vehicles": [{ "id": "NMR:Vehicle:102", "registrationNumber": "BB-102", "version": 1 }]
-      },
-      {
-        "id": "NMR:VehicleType:3",
-        "name": { "value": "Type Gamma" },
-        "length": 20,
-        "width": 3,
-        "height": 4,
-        "deckPlan": {
-          "id": "NMR:DeckPlan:3",
-          "description": "Articulated",
-          "name": { "value": "Plan C" }
-        },
-        "vehicles": [{ "id": "NMR:Vehicle:103", "registrationNumber": "CC-103", "version": 1 }]
-      }
-    ]
+        {
+          "id": "NMR:VehicleType:3",
+          "version": 1,
+          "name": { "value": "Type Gamma" },
+          "shortName": null,
+          "transportMode": null,
+          "length": 20,
+          "width": 3,
+          "height": 4,
+          "created": null,
+          "changed": null,
+          "changedBy": null,
+          "versionComment": null,
+          "deckPlan": {
+            "id": "NMR:DeckPlan:3",
+            "description": "Articulated",
+            "name": { "value": "Plan C" }
+          },
+          "vehicles": [{ "id": "NMR:Vehicle:103", "registrationNumber": "CC-103", "version": 1 }]
+        }
+      ],
+      "totalElements": 3,
+      "page": 0,
+      "size": 10000
+    }
   }
 }

--- a/src/data/deck-plans/deckPlanTypes.ts
+++ b/src/data/deck-plans/deckPlanTypes.ts
@@ -3,3 +3,10 @@ import type { DeckPlan } from '../vehicle-types/vehicleTypeTypes';
 export type DeckPlanContext = {
   deckPlans: DeckPlan[];
 };
+
+export type DeckPlanPage = {
+  content: DeckPlan[];
+  totalElements: number;
+  page: number;
+  size: number;
+};

--- a/src/data/deck-plans/deckPlanTypes.ts
+++ b/src/data/deck-plans/deckPlanTypes.ts
@@ -3,10 +3,3 @@ import type { DeckPlan } from '../vehicle-types/vehicleTypeTypes';
 export type DeckPlanContext = {
   deckPlans: DeckPlan[];
 };
-
-export type DeckPlanPage = {
-  content: DeckPlan[];
-  totalElements: number;
-  page: number;
-  size: number;
-};

--- a/src/data/deck-plans/fetchDeckPlans.ts
+++ b/src/data/deck-plans/fetchDeckPlans.ts
@@ -1,14 +1,13 @@
 import type { AccessToken } from '../../auth/index.ts';
 import { fetchDeckPlansRequest } from '../../graphql/vehicles/queries/fetchDeckPlans.ts';
-import type { DeckPlanContext } from './deckPlanTypes.ts';
-
-let fetchedDeckPlans: DeckPlanContext | undefined = undefined;
+import type { DeckPlanContext, DeckPlanPage } from './deckPlanTypes.ts';
 
 export const fetchDeckPlans = async (
   applicationBaseUrl: string,
   token: AccessToken
 ): Promise<DeckPlanContext> => {
-  fetchedDeckPlans = await fetchDeckPlansRequest(applicationBaseUrl, token);
-
-  return Object.assign({}, fetchedDeckPlans);
+  const raw: { deckPlans: DeckPlanPage } = await fetchDeckPlansRequest(applicationBaseUrl, token, {
+    size: 10000,
+  });
+  return { deckPlans: raw.deckPlans.content };
 };

--- a/src/data/deck-plans/fetchDeckPlans.ts
+++ b/src/data/deck-plans/fetchDeckPlans.ts
@@ -1,13 +1,18 @@
 import type { AccessToken } from '../../auth/index.ts';
 import { fetchDeckPlansRequest } from '../../graphql/vehicles/queries/fetchDeckPlans.ts';
-import type { DeckPlanContext, DeckPlanPage } from './deckPlanTypes.ts';
+import type { DeckPlanContext } from './deckPlanTypes.ts';
+import type { DeckPlan } from '../vehicle-types/vehicleTypeTypes.ts';
+import type { Page } from '../../types/paginationTypes.ts';
+import { FETCH_ALL_SIZE } from '../../types/paginationTypes.ts';
 
 export const fetchDeckPlans = async (
   applicationBaseUrl: string,
   token: AccessToken
 ): Promise<DeckPlanContext> => {
-  const raw: { deckPlans: DeckPlanPage } = await fetchDeckPlansRequest(applicationBaseUrl, token, {
-    size: 10000,
-  });
+  const raw: { deckPlans: Page<DeckPlan> } = await fetchDeckPlansRequest(
+    applicationBaseUrl,
+    token,
+    { size: FETCH_ALL_SIZE }
+  );
   return { deckPlans: raw.deckPlans.content };
 };

--- a/src/data/vehicle-types/fetchVehicleType.ts
+++ b/src/data/vehicle-types/fetchVehicleType.ts
@@ -1,13 +1,16 @@
 import { fetchVehicleTypeRequest } from '../../graphql/vehicles/queries/fetchVehicleType.ts';
-import type { VehicleType, VehicleTypeContext } from './vehicleTypeTypes.ts';
+import type { VehicleType, VehicleTypePage } from './vehicleTypeTypes.ts';
 import type { AccessToken } from '../../auth';
 
-// Workaround: fetches all vehicleTypes and filters by ID (entur/sobek#78)
 export const fetchVehicleType = async (
   applicationBaseUrl: string,
   id: string,
   token: AccessToken
 ): Promise<VehicleType | null> => {
-  const res: VehicleTypeContext = await fetchVehicleTypeRequest(applicationBaseUrl, token);
-  return res.vehicleTypes.find(vt => vt.id === id) ?? null;
+  const res: { vehicleTypes: VehicleTypePage } = await fetchVehicleTypeRequest(
+    applicationBaseUrl,
+    id,
+    token
+  );
+  return res.vehicleTypes.content[0] ?? null;
 };

--- a/src/data/vehicle-types/fetchVehicleType.ts
+++ b/src/data/vehicle-types/fetchVehicleType.ts
@@ -1,13 +1,14 @@
 import { fetchVehicleTypeRequest } from '../../graphql/vehicles/queries/fetchVehicleType.ts';
-import type { VehicleType, VehicleTypePage } from './vehicleTypeTypes.ts';
+import type { VehicleType } from './vehicleTypeTypes.ts';
 import type { AccessToken } from '../../auth';
+import type { Page } from '../../types/paginationTypes.ts';
 
 export const fetchVehicleType = async (
   applicationBaseUrl: string,
   id: string,
   token: AccessToken
 ): Promise<VehicleType | null> => {
-  const res: { vehicleTypes: VehicleTypePage } = await fetchVehicleTypeRequest(
+  const res: { vehicleTypes: Page<VehicleType> } = await fetchVehicleTypeRequest(
     applicationBaseUrl,
     id,
     token

--- a/src/data/vehicle-types/fetchVehicleTypes.ts
+++ b/src/data/vehicle-types/fetchVehicleTypes.ts
@@ -1,14 +1,15 @@
 import { fetchVehicleTypesRequest } from '../../graphql/vehicles/queries/fetchVehicleTypes.ts';
-import type { VehicleTypeContext } from './vehicleTypeTypes.ts';
+import type { VehicleTypeContext, VehicleTypePage } from './vehicleTypeTypes.ts';
 import type { AccessToken } from '../../auth';
-
-let fetchedVehicleTypes: VehicleTypeContext | undefined = undefined;
 
 export const fetchVehicleTypes = async (
   applicationBaseUrl: string,
   token: AccessToken
 ): Promise<VehicleTypeContext> => {
-  fetchedVehicleTypes = await fetchVehicleTypesRequest(applicationBaseUrl, token);
-
-  return Object.assign({}, fetchedVehicleTypes);
+  const raw: { vehicleTypes: VehicleTypePage } = await fetchVehicleTypesRequest(
+    applicationBaseUrl,
+    token,
+    { size: 10000 }
+  );
+  return { vehicleTypes: raw.vehicleTypes.content };
 };

--- a/src/data/vehicle-types/fetchVehicleTypes.ts
+++ b/src/data/vehicle-types/fetchVehicleTypes.ts
@@ -1,15 +1,17 @@
 import { fetchVehicleTypesRequest } from '../../graphql/vehicles/queries/fetchVehicleTypes.ts';
-import type { VehicleTypeContext, VehicleTypePage } from './vehicleTypeTypes.ts';
+import type { VehicleTypeContext, VehicleType } from './vehicleTypeTypes.ts';
 import type { AccessToken } from '../../auth';
+import type { Page } from '../../types/paginationTypes.ts';
+import { FETCH_ALL_SIZE } from '../../types/paginationTypes.ts';
 
 export const fetchVehicleTypes = async (
   applicationBaseUrl: string,
   token: AccessToken
 ): Promise<VehicleTypeContext> => {
-  const raw: { vehicleTypes: VehicleTypePage } = await fetchVehicleTypesRequest(
+  const raw: { vehicleTypes: Page<VehicleType> } = await fetchVehicleTypesRequest(
     applicationBaseUrl,
     token,
-    { size: 10000 }
+    { size: FETCH_ALL_SIZE }
   );
   return { vehicleTypes: raw.vehicleTypes.content };
 };

--- a/src/data/vehicle-types/vehicleTypeTypes.ts
+++ b/src/data/vehicle-types/vehicleTypeTypes.ts
@@ -37,13 +37,6 @@ export type VehicleTypeContext = {
   vehicleTypes: VehicleType[];
 };
 
-export type VehicleTypePage = {
-  content: VehicleType[];
-  totalElements: number;
-  page: number;
-  size: number;
-};
-
 export type NeTExPassengerCapacity = {
   StandingCapacity?: number;
   SeatingCapacity?: number;

--- a/src/data/vehicle-types/vehicleTypeTypes.ts
+++ b/src/data/vehicle-types/vehicleTypeTypes.ts
@@ -1,5 +1,6 @@
 export type Name = {
   value: string;
+  lang?: string;
 };
 
 export type DeckPlan = {
@@ -18,16 +19,29 @@ export type VehicleType = {
   id: string;
   version: number;
   name?: Name;
+  shortName?: Name;
+  transportMode?: string;
   deckPlan?: DeckPlan;
   length: number;
   width: number;
   height: number;
+  created?: string;
+  changed?: string;
+  changedBy?: string;
+  versionComment?: string;
   vehicles?: Vehicle[];
   __typename: string;
 };
 
 export type VehicleTypeContext = {
   vehicleTypes: VehicleType[];
+};
+
+export type VehicleTypePage = {
+  content: VehicleType[];
+  totalElements: number;
+  page: number;
+  size: number;
 };
 
 export type NeTExPassengerCapacity = {

--- a/src/graphql/vehicles/queries/fetchDeckPlans.ts
+++ b/src/graphql/vehicles/queries/fetchDeckPlans.ts
@@ -2,16 +2,25 @@ import { request, gql } from 'graphql-request';
 import { authHeader, type AccessToken } from '../../../auth';
 
 const fetchDeckPlansGQL = gql`
-  query DeckPlans {
-    deckPlans {
-      id
-      name {
-        value
+  query DeckPlans($page: Int, $size: Int) {
+    deckPlans(page: $page, size: $size) {
+      content {
+        id
+        name {
+          value
+        }
       }
+      totalElements
+      page
+      size
     }
   }
 `;
 
-export const fetchDeckPlansRequest = (applicationBaseUrl: string, token: AccessToken) => {
-  return request(applicationBaseUrl, fetchDeckPlansGQL, undefined, authHeader(token));
-};
+export type DeckPlanVars = { page?: number; size?: number };
+
+export const fetchDeckPlansRequest = (
+  applicationBaseUrl: string,
+  token: AccessToken,
+  variables?: DeckPlanVars
+) => request(applicationBaseUrl, fetchDeckPlansGQL, variables, authHeader(token));

--- a/src/graphql/vehicles/queries/fetchDeckPlans.ts
+++ b/src/graphql/vehicles/queries/fetchDeckPlans.ts
@@ -17,7 +17,9 @@ const fetchDeckPlansGQL = gql`
   }
 `;
 
-export type DeckPlanVars = { page?: number; size?: number };
+import type { PageVars } from '../../../types/paginationTypes.ts';
+
+export type DeckPlanVars = PageVars;
 
 export const fetchDeckPlansRequest = (
   applicationBaseUrl: string,

--- a/src/graphql/vehicles/queries/fetchVehicleType.ts
+++ b/src/graphql/vehicles/queries/fetchVehicleType.ts
@@ -1,34 +1,8 @@
-import { request, gql } from 'graphql-request';
-import { authHeader, type AccessToken } from '../../../auth';
+import { fetchVehicleTypesRequest } from './fetchVehicleTypes.ts';
+import type { AccessToken } from '../../../auth';
 
-// Workaround: Sobek lacks single-entity queries (entur/sobek#78).
-// Reuses the collection query; caller filters by ID.
-const fetchVehicleTypesGQL = gql`
-  query VehicleTypes {
-    vehicleTypes {
-      id
-      name {
-        value
-      }
-      length
-      width
-      height
-      deckPlan {
-        id
-        description
-        name {
-          value
-        }
-      }
-      vehicles {
-        id
-        registrationNumber
-        version
-      }
-    }
-  }
-`;
-
-export const fetchVehicleTypeRequest = (applicationBaseUrl: string, token: AccessToken) => {
-  return request(applicationBaseUrl, fetchVehicleTypesGQL, undefined, authHeader(token));
-};
+export const fetchVehicleTypeRequest = (
+  applicationBaseUrl: string,
+  id: string,
+  token: AccessToken
+) => fetchVehicleTypesRequest(applicationBaseUrl, token, { size: 1, filter: { ids: [id] } });

--- a/src/graphql/vehicles/queries/fetchVehicleTypes.ts
+++ b/src/graphql/vehicles/queries/fetchVehicleTypes.ts
@@ -41,9 +41,9 @@ const fetchVehicleTypesGQL = gql`
   }
 `;
 
-export type VehicleTypeVars = {
-  page?: number;
-  size?: number;
+import type { PageVars } from '../../../types/paginationTypes.ts';
+
+export type VehicleTypeVars = PageVars & {
   filter?: { ids?: string[]; transportMode?: string };
 };
 

--- a/src/graphql/vehicles/queries/fetchVehicleTypes.ts
+++ b/src/graphql/vehicles/queries/fetchVehicleTypes.ts
@@ -2,31 +2,53 @@ import { request, gql } from 'graphql-request';
 import { authHeader, type AccessToken } from '../../../auth';
 
 const fetchVehicleTypesGQL = gql`
-  query VehicleTypes {
-    vehicleTypes {
-      id
-      name {
-        value
-      }
-      length
-      width
-      height
-      deckPlan {
+  query VehicleTypes($page: Int, $size: Int, $filter: VehicleTypeFilter) {
+    vehicleTypes(page: $page, size: $size, filter: $filter) {
+      content {
         id
-        description
+        version
         name {
           value
         }
+        shortName {
+          value
+        }
+        transportMode
+        length
+        width
+        height
+        created
+        changed
+        changedBy
+        versionComment
+        deckPlan {
+          id
+          description
+          name {
+            value
+          }
+        }
+        vehicles {
+          id
+          registrationNumber
+          version
+        }
       }
-      vehicles {
-        id
-        registrationNumber
-        version
-      }
+      totalElements
+      page
+      size
     }
   }
 `;
 
-export const fetchVehicleTypesRequest = (applicationBaseUrl: string, token: AccessToken) => {
-  return request(applicationBaseUrl, fetchVehicleTypesGQL, undefined, authHeader(token));
+export type VehicleTypeVars = {
+  page?: number;
+  size?: number;
+  filter?: { ids?: string[]; transportMode?: string };
 };
+
+export const fetchVehicleTypesRequest = (
+  applicationBaseUrl: string,
+  token: AccessToken,
+  variables?: VehicleTypeVars
+) => request(applicationBaseUrl, fetchVehicleTypesGQL, variables, authHeader(token));

--- a/src/types/paginationTypes.ts
+++ b/src/types/paginationTypes.ts
@@ -1,0 +1,13 @@
+export type Page<T> = {
+  content: T[];
+  totalElements: number;
+  page: number;
+  size: number;
+};
+
+export type PageVars = {
+  page?: number;
+  size?: number;
+};
+
+export const FETCH_ALL_SIZE = 10000;


### PR DESCRIPTION
## Summary

- Update `vehicleTypes` and `deckPlans` GQL queries to use the new paged response shape (`VehicleTypePage`/`DeckPlanPage` with `content`, `totalElements`, `page`, `size`)
- Add new VehicleType fields: `transportMode`, `shortName`, `created`, `changed`, `changedBy`, `versionComment`
- Replace fetch-all-then-filter-by-ID workaround with targeted `ids` filter for single-entity lookups
- Data service layer unwraps the page envelope so hooks and UI remain unchanged

Depends on entur/sobek#86 (backend paged queries).

Refs: entur/sobek#85, entur/sobek#86, #23, #24

## Test plan

- [ ] `npm run build` passes (TS compiles clean)
- [ ] `npm run lint` passes (0 errors)
- [ ] Manual: VehicleType list page loads against local Sobek (PR #86 branch)
- [ ] Manual: DeckPlan list page loads against local Sobek
- [ ] Manual: Single vehicle type detail panel loads (uses `ids` filter)

🤖 Generated with [Claude Code](https://claude.com/claude-code)