### PR TITLE
vehicle-types: blanks-last sort + drop deckPlan.description

### DIFF
--- a/src/data/vehicle-types/useVehicleTypes.ts
+++ b/src/data/vehicle-types/useVehicleTypes.ts
@@ -4,6 +4,7 @@ import { useSearchParams } from 'react-router-dom';
 import { useConfig } from '../../contexts/configContext.ts';
 import type { VehicleType, VehicleTypeContext } from './vehicleTypeTypes.js';
 import { fetchVehicleTypes } from './fetchVehicleTypes.ts';
+import { getVehicleTypeSortValue } from './vehicleTypeSortValue.ts';
 import type { Order } from '../../components/data/dataTableTypes.ts';
 import { useAuth } from '../../auth/authUtils.ts';
 
@@ -73,10 +74,17 @@ export function useVehicleTypes() {
   };
 
   const sorted = [...data].sort((a, b) => {
-    const v1 = orderBy === 'name' ? a.name?.value?.toLowerCase() || '' : a.id.toLowerCase();
-    const v2 = orderBy === 'name' ? b.name?.value?.toLowerCase() || '' : b.id.toLowerCase();
-    if (v1 < v2) return order === 'asc' ? -1 : 1;
-    if (v1 > v2) return order === 'asc' ? 1 : -1;
+    const va = getVehicleTypeSortValue(a, orderBy);
+    const vb = getVehicleTypeSortValue(b, orderBy);
+    const aEmpty = va === '' || va == null;
+    const bEmpty = vb === '' || vb == null;
+    if (aEmpty && bEmpty) return 0;
+    if (aEmpty) return 1;
+    if (bEmpty) return -1;
+    const ca = typeof va === 'string' ? va.toLowerCase() : va;
+    const cb = typeof vb === 'string' ? vb.toLowerCase() : vb;
+    if (ca < cb) return order === 'asc' ? -1 : 1;
+    if (ca > cb) return order === 'asc' ? 1 : -1;
     return 0;
   });
 

--- a/src/data/vehicle-types/useVehicleTypes.ts
+++ b/src/data/vehicle-types/useVehicleTypes.ts
@@ -4,7 +4,7 @@ import { useSearchParams } from 'react-router-dom';
 import { useConfig } from '../../contexts/configContext.ts';
 import type { VehicleType, VehicleTypeContext } from './vehicleTypeTypes.js';
 import { fetchVehicleTypes } from './fetchVehicleTypes.ts';
-import { getVehicleTypeSortValue } from './vehicleTypeSortValue.ts';
+import { compareVehicleTypes } from './vehicleTypeSortValue.ts';
 import type { Order } from '../../components/data/dataTableTypes.ts';
 import { useAuth } from '../../auth/authUtils.ts';
 
@@ -73,20 +73,7 @@ export function useVehicleTypes() {
     setOrderBy(property);
   };
 
-  const sorted = [...data].sort((a, b) => {
-    const va = getVehicleTypeSortValue(a, orderBy);
-    const vb = getVehicleTypeSortValue(b, orderBy);
-    const aEmpty = va === '' || va == null;
-    const bEmpty = vb === '' || vb == null;
-    if (aEmpty && bEmpty) return 0;
-    if (aEmpty) return 1;
-    if (bEmpty) return -1;
-    const ca = typeof va === 'string' ? va.toLowerCase() : va;
-    const cb = typeof vb === 'string' ? vb.toLowerCase() : vb;
-    if (ca < cb) return order === 'asc' ? -1 : 1;
-    if (ca > cb) return order === 'asc' ? 1 : -1;
-    return 0;
-  });
+  const sorted = [...data].sort(compareVehicleTypes(orderBy, order));
 
   const paginated = sorted.slice(page * rowsPerPage, (page + 1) * rowsPerPage);
 

--- a/src/data/vehicle-types/vehicleTypeSortValue.test.ts
+++ b/src/data/vehicle-types/vehicleTypeSortValue.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest';
+import { compareVehicleTypes, getVehicleTypeSortValue } from './vehicleTypeSortValue.ts';
+import type { VehicleType } from './vehicleTypeTypes.ts';
+
+const mk = (over: Partial<VehicleType>): VehicleType =>
+  ({
+    id: 'NMR:VehicleType:x',
+    version: 1,
+    length: 0,
+    width: 0,
+    height: 0,
+    ...over,
+  }) as VehicleType;
+
+describe('compareVehicleTypes', () => {
+  it('asc by name keeps rows with no Name at the end (regression: blanks-first bug)', () => {
+    const rows = [
+      mk({ id: 'a', name: undefined }),
+      mk({ id: 'b', name: { value: 'Bravo' } }),
+      mk({ id: 'c', name: undefined }),
+      mk({ id: 'd', name: { value: 'Alpha' } }),
+    ];
+    const sorted = [...rows].sort(compareVehicleTypes('name', 'asc'));
+    expect(sorted.map(r => r.id)).toEqual(['d', 'b', 'a', 'c']);
+  });
+
+  it('desc by name also keeps blanks at the end (not flipped to top)', () => {
+    const rows = [
+      mk({ id: 'a', name: undefined }),
+      mk({ id: 'b', name: { value: 'Bravo' } }),
+      mk({ id: 'd', name: { value: 'Alpha' } }),
+    ];
+    const sorted = [...rows].sort(compareVehicleTypes('name', 'desc'));
+    expect(sorted.map(r => r.id)).toEqual(['b', 'd', 'a']);
+  });
+
+  it('sorts populated names case-insensitively', () => {
+    const rows = [
+      mk({ id: '1', name: { value: 'banana' } }),
+      mk({ id: '2', name: { value: 'Apple' } }),
+      mk({ id: '3', name: { value: 'cherry' } }),
+    ];
+    const sorted = [...rows].sort(compareVehicleTypes('name', 'asc'));
+    expect(sorted.map(r => r.name?.value)).toEqual(['Apple', 'banana', 'cherry']);
+  });
+
+  it('sorts dimensions numerically (regression: previously fell through to id)', () => {
+    const rows = [
+      mk({ id: 'big', length: 20 }),
+      mk({ id: 'small', length: 3 }),
+      mk({ id: 'mid', length: 10 }),
+    ];
+    const sorted = [...rows].sort(compareVehicleTypes('dimensions', 'asc'));
+    expect(sorted.map(r => r.length)).toEqual([3, 10, 20]);
+  });
+
+  it('treats length === 0 as a real value, not empty', () => {
+    const rows = [mk({ id: 'zero', length: 0 }), mk({ id: 'one', length: 1 })];
+    const sorted = [...rows].sort(compareVehicleTypes('dimensions', 'asc'));
+    expect(sorted.map(r => r.id)).toEqual(['zero', 'one']);
+  });
+
+  it('sorts by deckPlanName and parks rows without a deckPlan at the end', () => {
+    const rows = [
+      mk({ id: 'a', deckPlan: undefined }),
+      mk({ id: 'b', deckPlan: { id: 'd1', name: { value: 'Zulu' } } }),
+      mk({ id: 'c', deckPlan: { id: 'd2', name: { value: 'Alpha' } } }),
+    ];
+    const sorted = [...rows].sort(compareVehicleTypes('deckPlanName', 'asc'));
+    expect(sorted.map(r => r.id)).toEqual(['c', 'b', 'a']);
+  });
+});
+
+describe('getVehicleTypeSortValue', () => {
+  it('returns empty string for missing optional fields', () => {
+    const r = mk({ name: undefined, deckPlan: undefined });
+    expect(getVehicleTypeSortValue(r, 'name')).toBe('');
+    expect(getVehicleTypeSortValue(r, 'deckPlanName')).toBe('');
+  });
+});

--- a/src/data/vehicle-types/vehicleTypeSortValue.ts
+++ b/src/data/vehicle-types/vehicleTypeSortValue.ts
@@ -1,0 +1,17 @@
+import type { VehicleType } from './vehicleTypeTypes.ts';
+import type { OrderBy } from './useVehicleTypes.ts';
+
+export const getVehicleTypeSortValue = (item: VehicleType, key: OrderBy): string | number => {
+  switch (key) {
+    case 'name':
+      return item.name?.value || '';
+    case 'id':
+      return item.id;
+    case 'dimensions':
+      return item.length;
+    case 'deckPlanName':
+      return item.deckPlan?.name?.value || '';
+    default:
+      return '';
+  }
+};

--- a/src/data/vehicle-types/vehicleTypeSortValue.ts
+++ b/src/data/vehicle-types/vehicleTypeSortValue.ts
@@ -1,3 +1,4 @@
+import type { Order } from '../../components/data/dataTableTypes.ts';
 import type { VehicleType } from './vehicleTypeTypes.ts';
 import type { OrderBy } from './useVehicleTypes.ts';
 
@@ -15,3 +16,22 @@ export const getVehicleTypeSortValue = (item: VehicleType, key: OrderBy): string
       return '';
   }
 };
+
+// Empty/nullish values sort to the end regardless of direction so VehicleTypes
+// missing an optional NeTEx Name (etc.) don't dominate the first page.
+export const compareVehicleTypes =
+  (orderBy: OrderBy, order: Order) =>
+  (a: VehicleType, b: VehicleType): number => {
+    const va = getVehicleTypeSortValue(a, orderBy);
+    const vb = getVehicleTypeSortValue(b, orderBy);
+    const aEmpty = va === '' || va == null;
+    const bEmpty = vb === '' || vb == null;
+    if (aEmpty && bEmpty) return 0;
+    if (aEmpty) return 1;
+    if (bEmpty) return -1;
+    const ca = typeof va === 'string' ? va.toLowerCase() : va;
+    const cb = typeof vb === 'string' ? vb.toLowerCase() : vb;
+    if (ca < cb) return order === 'asc' ? -1 : 1;
+    if (ca > cb) return order === 'asc' ? 1 : -1;
+    return 0;
+  };

--- a/src/data/vehicle-types/vehicleTypeTypes.ts
+++ b/src/data/vehicle-types/vehicleTypeTypes.ts
@@ -5,7 +5,6 @@ export type Name = {
 
 export type DeckPlan = {
   id: string;
-  description?: string;
   name?: Name;
 };
 

--- a/src/data/vehicle-types/vehicleTypeViewConfig.tsx
+++ b/src/data/vehicle-types/vehicleTypeViewConfig.tsx
@@ -9,6 +9,7 @@ import type { ColumnDefinition } from '../../components/data/dataTableTypes.ts';
 import type { OrderBy } from './useVehicleTypes.ts';
 import type { FilterDefinition } from '../../components/search/searchTypes.ts';
 import type { VehicleType } from './vehicleTypeTypes.ts';
+import { getVehicleTypeSortValue } from './vehicleTypeSortValue.ts';
 
 const fmtDim = (v: VehicleType) => {
   const parts = [
@@ -73,21 +74,6 @@ const vehicleTypeColumns: ColumnDefinition<VehicleType, OrderBy>[] = [
 
 const getVehicleTypeFilterKey = (item: VehicleType): string => {
   return item.id;
-};
-
-const getVehicleTypeSortValue = (item: VehicleType, key: OrderBy): string | number => {
-  switch (key) {
-    case 'name':
-      return item.name?.value || '';
-    case 'id':
-      return item.id;
-    case 'dimensions':
-      return item.length;
-    case 'deckPlanName':
-      return item.deckPlan?.name?.value || '';
-    default:
-      return '';
-  }
 };
 
 const vehicleTypeFilters: FilterDefinition[] = [

--- a/src/graphql/vehicles/queries/fetchVehicleTypes.ts
+++ b/src/graphql/vehicles/queries/fetchVehicleTypes.ts
@@ -23,7 +23,6 @@ const fetchVehicleTypesGQL = gql`
         versionComment
         deckPlan {
           id
-          description
           name {
             value
           }


### PR DESCRIPTION
## Summary

- Fix the Name column appearing empty on first load of `/vehicle-type`. The default sort (`name asc`) plus an inline comparator that coerced missing `name?.value` to `''` was pushing every VehicleType lacking a NeTEx Name to the front of the first page. New comparator delegates to `getVehicleTypeSortValue` and pushes empty/nullish values to the end regardless of direction. As a side effect, `dimensions` and `deckPlanName` headers actually sort by their column content now (the previous comparator silently fell through to `id`).
- Lift the comparator into `vehicleTypeSortValue.ts` and add a vitest spec — `compareVehicleTypes` is unit-tested for the blanks-last invariant under both asc and desc, plus regression coverage for `dimensions`/`deckPlanName`.
- Drop `deckPlan.description` from the VehicleTypes query and TS type. Sobek (entur/sobek#115) changed the field's GraphQL type to `EmbeddableMultilingualString`, breaking validation against any current backend; the field has zero render sites in hathor.

Fixes #61.
Fixes #52.

## Test plan

- [x] `npm run lint`
- [x] `npm run check`
- [x] `npx tsc -b`
- [x] `npm test` (70/70 passing, including 7 new specs in `vehicleTypeSortValue.test.ts`)
- [ ] `npm run local`, navigate to `/vehicle-type`, confirm first page shows rows with populated names and that nameless rows sit at the bottom in both asc and desc
- [ ] Click each sortable column header and verify the table actually orders by that column's content

## Follow-up

`useDeckPlans.ts` carries the same broken inline comparator the old `useVehicleTypes` did. Filed as a separate issue with a note about lifting the helper into `src/utils/` once a third caller exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)