### PR TITLE
fix: adapt vehicleTypes filter to sobek transportModes list (#70)

### DIFF
--- a/src/graphql/vehicles/queries/fetchVehicleTypes.ts
+++ b/src/graphql/vehicles/queries/fetchVehicleTypes.ts
@@ -43,7 +43,7 @@ const fetchVehicleTypesGQL = gql`
 import type { PageVars } from '../../paginationTypes.ts';
 
 export type VehicleTypeVars = PageVars & {
-  filter?: { ids?: string[]; transportMode?: string };
+  filter?: { ids?: string[]; transportModes?: string[] };
 };
 
 export const fetchVehicleTypesRequest = (


### PR DESCRIPTION
## Summary
- Updates `VehicleTypeVars.filter` to use `transportModes?: string[]` instead of `transportMode?: string`, matching the renamed `vehicleTypes` filter argument from sobek [PR #123](https://github.com/entur/sobek/pull/123).
- Type-only change. No call sites currently pass `transportMode` — the umbrella TransportMode chip filter (issue #24) will land on top of this contract.

Closes #70

## Test plan
- [x] `npx tsc -b --noEmit` — clean
- [x] `npm run check` (prettier) — clean
- [x] `npm run lint` — 0 errors (9 pre-existing warnings, none in changed file)
- [x] `npm run test` — 78/78 pass
- [ ] Coordinate merge with sobek#123 deploy to dev to avoid a transient mismatch

🤖 Generated with [Claude Code](https://claude.com/claude-code)