### PR TITLE
(overlook)

### DIFF
--- a/e2e-tests/no-auth/vehicle-create-feedback.spec.ts
+++ b/e2e-tests/no-auth/vehicle-create-feedback.spec.ts
@@ -99,6 +99,50 @@ test.describe('/vehicles/new save feedback + redirect (no-auth)', () => {
     await expect(page.getByText('Vehicle not found')).toHaveCount(0);
   });
 
+  test('save → View in list resolves the slider on the assigned id (id-agnostic, backend-safe)', async ({
+    page,
+  }) => {
+    // Unlike the tests above, this one does not assume `NEW_ID` — it reads
+    // back whatever id the redirect produced. That makes it valid against a
+    // live Sobek (`E2E_BACKEND=true`), where the assigned id is unknown
+    // until the import POST responds.
+    await wireCreateFlow(page, { lag: 0 });
+    await page.goto('/vehicles/new');
+    await page.waitForLoadState('networkidle');
+
+    await fillRequiredFields(page);
+    await page.getByRole('button', { name: 'Save' }).click();
+    await page.getByRole('button', { name: 'View in list' }).click();
+
+    await expect.poll(() => page.url(), { timeout: 15_000 }).toMatch(/[?&]selected=/);
+    await expect(page.getByTestId('vehicle-details-title')).toBeVisible();
+    await expect(page.getByText('Vehicle not found')).toHaveCount(0);
+  });
+
+  test('save with a Name → View in list → sidebar shows that Name (round-trip, backend-only)', async ({
+    page,
+  }) => {
+    // Backend-only: the mock single-vehicle GET returns a fixed body, so a
+    // name round-trip can only be proven against a live Sobek. End-to-end
+    // check for the #80 item-1 parser fix — a bare <Name> with no lang
+    // attribute must survive POST → persist → GET → parse → render.
+    test.skip(process.env.E2E_BACKEND !== 'true', 'backend-only — needs real name persistence');
+
+    const name = `E2E Name ${Date.now()}`;
+    await wireCreateFlow(page);
+    await page.goto('/vehicles/new');
+    await page.waitForLoadState('networkidle');
+
+    await page.locator('#vehicle-name').fill(name);
+    await fillRequiredFields(page);
+    await page.getByRole('button', { name: 'Save' }).click();
+    await page.getByRole('button', { name: 'View in list' }).click();
+
+    await expect.poll(() => page.url(), { timeout: 15_000 }).toMatch(/[?&]selected=/);
+    await expect(page.getByTestId('vehicle-details-title')).toHaveText(name);
+    await expect(page.getByText('Vehicle not found')).toHaveCount(0);
+  });
+
   test('action waits out replica lag, then slider resolves (poll-until-found)', async ({
     page,
   }) => {

--- a/e2e-tests/no-auth/vehicle-form-80-fixes.spec.ts
+++ b/e2e-tests/no-auth/vehicle-form-80-fixes.spec.ts
@@ -1,0 +1,121 @@
+import { test, expect, type Page } from '@playwright/test';
+import * as fs from 'fs';
+import * as path from 'path';
+import { fileURLToPath } from 'url';
+import {
+  interceptVehicleListQuery,
+  netexName,
+  vehiclePublicationDelivery,
+} from './vehicle-list-helpers';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const fixturesDir = path.join(__dirname, '..', 'fixtures');
+const targetConfig = path.join(__dirname, '..', '..', 'public', 'config.json');
+
+const VEHICLE_ID = 'NMR:Vehicle:rail-1';
+const SELECTED = `/vehicles?selected=${encodeURIComponent(VEHICLE_ID)}`;
+
+/**
+ * Regression coverage for the three remaining bugs in hathor #80:
+ *
+ *   1. Vehicle Name renders blank — Sobek's exporter wraps the value in a
+ *      nested <Text> element (`<Name><Text>Foo</Text></Name>`), a shape
+ *      `projectText` did not unwrap, so the value was silently dropped.
+ *   2. Build/Registration dates were plain text inputs with no picker.
+ *   4. After a successful save the dirty baseline was never advanced (the
+ *      single-vehicle XML was not refetched), so closing the slider with
+ *      `>>` wrongly raised the discard dialog.
+ *
+ * Mock-only — the asserted Name/date values are fixture-controlled, so this
+ * spec is meaningless against a live backend.
+ */
+test.describe('/vehicles slider — #80 form bug fixes (no-auth)', () => {
+  test.skip(process.env.E2E_BACKEND === 'true', 'mock-only regression spec');
+
+  test.beforeAll(() => {
+    fs.copyFileSync(path.join(fixturesDir, 'config-no-auth.json'), targetConfig);
+  });
+
+  /** Route the single-vehicle NeTEx GET to a PublicationDelivery whose
+   *  `<Vehicle>` body is caller-supplied — lets each test pin the exact
+   *  Name/date elements it asserts on. */
+  const routeVehicleXml = (page: Page, body: string) =>
+    page.route('**/services/vehicles/netex/vehicles/**', async route => {
+      if (route.request().method() !== 'GET') return route.continue();
+      const id = decodeURIComponent(new URL(route.request().url()).pathname.split('/').pop() ?? '');
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/xml',
+        body: vehiclePublicationDelivery(id, body),
+      });
+    });
+
+  test("Name parsed from Sobek's <Name><Text> shape shows in the title and form field", async ({
+    page,
+  }) => {
+    await interceptVehicleListQuery(page);
+    await routeVehicleXml(page, netexName('Oslo Tram 4'));
+
+    await page.goto(SELECTED);
+    await page.waitForLoadState('networkidle');
+
+    await expect(page.getByTestId('vehicle-details-title')).toHaveText('Oslo Tram 4');
+    await expect(page.locator('#vehicle-name')).toHaveValue('Oslo Tram 4');
+  });
+
+  test('Build and Registration dates render as native date inputs bound to the XML value', async ({
+    page,
+  }) => {
+    await interceptVehicleListQuery(page);
+    await routeVehicleXml(
+      page,
+      netexName('Oslo Tram 4') +
+        '<BuildDate>2019-04-10</BuildDate>' +
+        '<RegistrationDate>2020-08-22</RegistrationDate>'
+    );
+
+    await page.goto(SELECTED);
+    await page.waitForLoadState('networkidle');
+
+    const build = page.locator('#vehicle-build-date');
+    const reg = page.locator('#vehicle-registration-date');
+
+    await expect(build).toHaveAttribute('type', 'date');
+    await expect(build).toHaveValue('2019-04-10');
+    await expect(reg).toHaveAttribute('type', 'date');
+    await expect(reg).toHaveValue('2020-08-22');
+  });
+
+  test('closing the slider after a successful save does not raise the discard dialog', async ({
+    page,
+  }) => {
+    await interceptVehicleListQuery(page);
+    await routeVehicleXml(page, netexName('Oslo Tram 4'));
+    await page.route('**/services/vehicles/netex', async route => {
+      if (route.request().method() !== 'POST') return route.continue();
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/xml',
+        body: vehiclePublicationDelivery(VEHICLE_ID),
+      });
+    });
+
+    await page.goto(SELECTED);
+    await page.waitForLoadState('networkidle');
+
+    await page.getByTestId('editor-rail-edit').click();
+    await page.locator('#vehicle-name').fill('Oslo Tram 4 — renamed');
+    await page.getByTestId('editor-rail-save').click();
+
+    // Save success → snackbar; the XML refetch must re-baseline the form so
+    // the slider is no longer considered dirty.
+    await expect(page.getByText('Vehicle saved')).toBeVisible();
+
+    await page.getByTestId('editor-rail-collapse').click();
+
+    await expect(page.getByRole('button', { name: 'Discard' })).toHaveCount(0);
+    await expect(page).not.toHaveURL(/selected=/);
+  });
+});

--- a/e2e-tests/no-auth/vehicle-list-helpers.ts
+++ b/e2e-tests/no-auth/vehicle-list-helpers.ts
@@ -98,9 +98,15 @@ const makeExtraVehicle = (id: string) => ({
   },
 });
 
+/** Sobek wraps every multilingual value in a nested `<Text>` element —
+ *  `<Name><Text>…</Text></Name>` (confirmed via live probe). Mirror that exact
+ *  shape in mocks so the parser is exercised against reality rather than a
+ *  friendlier invented `<Name>value</Name>` shape that masks round-trip bugs. */
+export const netexName = (value: string) => `<Name><Text>${value}</Text></Name>`;
+
 /** Minimal PublicationDelivery wrapping a single Vehicle. `body` is inserted
  *  inside the `<Vehicle>` element — leave empty for a bare echo, or pass
- *  e.g. "<Name>X</Name><RegistrationNumber>R</RegistrationNumber>". */
+ *  e.g. `${netexName('X')}<RegistrationNumber>R</RegistrationNumber>`. */
 export const vehiclePublicationDelivery = (id: string, body = '') =>
   `<?xml version="1.0" encoding="UTF-8"?>
 <PublicationDelivery xmlns="http://www.netex.org.uk/netex">
@@ -150,7 +156,7 @@ export const interceptVehicleNetexGet = (page: Page) =>
       contentType: 'application/xml',
       body: vehiclePublicationDelivery(
         id,
-        '<Name>Newly created</Name><RegistrationNumber>NEW-001</RegistrationNumber>'
+        `${netexName('Newly created')}<RegistrationNumber>NEW-001</RegistrationNumber>`
       ),
     });
   });

--- a/src/data/netex/parser-helpers.ts
+++ b/src/data/netex/parser-helpers.ts
@@ -36,11 +36,24 @@ export function textArr(raw: Obj, key: string, out: Obj) {
   out[key] = arr.map(projectText);
 }
 
-function projectText(raw: Obj) {
+/**
+ * Normalise one NeTEx multilingual-text node to `{ value, $lang? }`. Three
+ * shapes occur in the wild and all must be handled:
+ *   - `<Name>Foo</Name>`              → primitive `'Foo'`     (attribute-less;
+ *      fast-xml-parser only emits `#text` for attribute-bearing elements)
+ *   - `<Name lang="no">Foo</Name>`    → `{ '#text', '@_lang' }`  (standard NeTEx)
+ *   - `<Name><Text>Foo</Text></Name>` → `{ Text: 'Foo' }`  (Sobek's exporter —
+ *      confirmed via live probe; this is what the single-vehicle GET returns)
+ */
+function projectText(raw: unknown) {
+  const node = raw && typeof raw === 'object' && 'Text' in raw ? (raw as Obj)['Text'] : raw;
+  if (node == null) return {};
+  if (typeof node !== 'object') return { value: String(node) };
+  const n = node as Obj;
   const t: { value?: string; $lang?: string; $textIdType?: string } = {};
-  if (raw['#text'] !== undefined) t.value = String(raw['#text']);
-  if (raw['@_lang'] !== undefined) t.$lang = String(raw['@_lang']);
-  if (raw['@_textIdType'] !== undefined) t.$textIdType = String(raw['@_textIdType']);
+  if (n['#text'] !== undefined) t.value = String(n['#text']);
+  if (n['@_lang'] !== undefined) t.$lang = String(n['@_lang']);
+  if (n['@_textIdType'] !== undefined) t.$textIdType = String(n['@_textIdType']);
   return t;
 }
 

--- a/src/data/vehicles/VehicleDetails.tsx
+++ b/src/data/vehicles/VehicleDetails.tsx
@@ -50,7 +50,12 @@ export default function VehicleDetails({ vehicle, onSaved }: VehicleDetailsProps
   const [savedAt, setSavedAt] = useState<number | null>(null);
   const { save, saving, error, clearError } = useVehiclePairSave();
 
-  const { data: xmlVehicle, loading: xmlLoading, error: xmlError } = useVehicle(vehicle?.id);
+  const {
+    data: xmlVehicle,
+    loading: xmlLoading,
+    error: xmlError,
+    refetch: refetchXml,
+  } = useVehicle(vehicle?.id);
 
   useEffect(() => {
     dispatch({ type: 'hydrate', xmlVehicle });
@@ -71,6 +76,10 @@ export default function VehicleDetails({ vehicle, onSaved }: VehicleDetailsProps
   const handleSave = async () => {
     const result = await commitSave(save, form, onSaved);
     if (!result.error) {
+      // Re-pull the persisted vehicle so the `hydrate` effect advances the
+      // dirty baseline (and picks up the bumped version). Without this the
+      // form stays dirty after save and `>>` wrongly raises the discard dialog.
+      await refetchXml();
       setSavedAt(Date.now());
       setMode('view');
     }

--- a/src/data/vehicles/VehicleEditForm.tsx
+++ b/src/data/vehicles/VehicleEditForm.tsx
@@ -11,7 +11,6 @@ export const LABEL_COL_MIN = '8rem';
 export const LABEL_COL_MAX = '12rem';
 export const COL_GAP = 2;
 export const ROW_GAP = 1.25;
-const DATE_PLACEHOLDER = 'YYYY-MM-DD';
 
 export interface VehicleEditFormValue {
   vehicle: Vehicle;
@@ -157,12 +156,12 @@ export default function VehicleEditForm({ value, onChange, mode }: VehicleEditFo
       <FieldRow id="vehicle-build-date" label={t('vehicles.field.buildDate', 'Build Date')}>
         <TextField
           id="vehicle-build-date"
-          value={v.BuildDate ?? ''}
+          type="date"
+          value={(v.BuildDate ?? '').slice(0, 10)}
           onChange={e => setV({ BuildDate: orUndef(e.target.value) })}
           disabled={ro}
           size="small"
           fullWidth
-          placeholder={DATE_PLACEHOLDER}
         />
       </FieldRow>
 
@@ -172,12 +171,12 @@ export default function VehicleEditForm({ value, onChange, mode }: VehicleEditFo
       >
         <TextField
           id="vehicle-registration-date"
-          value={v.RegistrationDate ?? ''}
+          type="date"
+          value={(v.RegistrationDate ?? '').slice(0, 10)}
           onChange={e => setV({ RegistrationDate: orUndef(e.target.value) })}
           disabled={ro}
           size="small"
           fullWidth
-          placeholder={DATE_PLACEHOLDER}
         />
       </FieldRow>
 

--- a/src/data/vehicles/xml/Vehicle-parser.test.ts
+++ b/src/data/vehicles/xml/Vehicle-parser.test.ts
@@ -71,6 +71,36 @@ const MULTI_NAME_XML = `<?xml version="1.0" encoding="UTF-8"?>
   </dataObjects>
 </PublicationDelivery>`;
 
+const BARE_NAME_XML = `<?xml version="1.0" encoding="UTF-8"?>
+<PublicationDelivery xmlns="http://www.netex.org.uk/netex" version="1.0">
+  <dataObjects>
+    <ResourceFrame id="X:RF:1" version="1">
+      <vehicles>
+        <Vehicle id="X:V:1" version="1">
+          <Name>Bare Name</Name>
+          <RegistrationNumber>BN-0001</RegistrationNumber>
+        </Vehicle>
+      </vehicles>
+    </ResourceFrame>
+  </dataObjects>
+</PublicationDelivery>`;
+
+const SOBEK_NAME_XML = `<?xml version="1.0" encoding="UTF-8"?>
+<PublicationDelivery xmlns="http://www.netex.org.uk/netex" version="1.0">
+  <dataObjects>
+    <ResourceFrame id="X:RF:1" version="1">
+      <vehicles>
+        <Vehicle id="X:V:1" version="1">
+          <Name>
+            <Text>Sobek Wrapped Name</Text>
+          </Name>
+          <RegistrationNumber>SW-0001</RegistrationNumber>
+        </Vehicle>
+      </vehicles>
+    </ResourceFrame>
+  </dataObjects>
+</PublicationDelivery>`;
+
 describe('parseVehicleXml', () => {
   it('maps the seed fixture into the Vehicle domain shape', () => {
     const v = parseVehicleXml(SEED_XML);
@@ -104,6 +134,29 @@ describe('parseVehicleXml', () => {
     const single = parseVehicleXml(SEED_XML);
     expect(Array.isArray(single?.Name)).toBe(true);
     expect(single?.Name).toHaveLength(1);
+  });
+
+  it('parses a bare <Name> with no lang attribute (#80 — projectText dropped primitive text nodes)', () => {
+    const v = parseVehicleXml(BARE_NAME_XML);
+    expect(v?.Name?.[0]?.value).toBe('Bare Name');
+  });
+
+  it("parses Sobek's <Name><Text>…</Text></Name> export shape (#80 — the real single-vehicle GET shape)", () => {
+    const v = parseVehicleXml(SOBEK_NAME_XML);
+    expect(v?.Name?.[0]?.value).toBe('Sobek Wrapped Name');
+  });
+
+  it('round-trips a Name carrying no lang — hathor serializes attribute-less <Name>', () => {
+    const input = {
+      $id: 'X:V:1',
+      $version: '1',
+      Name: [{ value: 'No Lang Name' }],
+      RegistrationNumber: 'NL-0001',
+    };
+    const xml = buildPublicationDeliveryXml({
+      vehicles: [vehicleToXmlShape(input as Record<string, unknown>)],
+    });
+    expect(parseVehicleXml(xml)?.Name?.[0]?.value).toBe('No Lang Name');
   });
 
   it('round-trips Refs with domain→xml aliases (M1: TransportOrganisationRef ↔ <AuthorityRef>, VehicleModelProfileRef ↔ <CarModelProfileRef>)', () => {


### PR DESCRIPTION
## Summary

- **Name blank** — Sobek's NeTEx exporter wraps values as `<Name><Text>…</Text></Name>`; `projectText` now unwraps that shape (confirmed via a live POST+GET probe). The e2e/vitest mocks used `<Name>value</Name>`, which masked the bug — now corrected to the real shape via a `netexName()` helper.
- **Dates** — `BuildDate` / `RegistrationDate` swapped to native `type="date"` inputs.
- **Post-save dirty** — `handleSave` now refetches the persisted vehicle so the dirty baseline re-hydrates; closing the slider with `>>` no longer raises a stale discard dialog.

Verified end-to-end against live Sobek: save (with name) → View in list → sidebar shows the persisted name.

Stacked on #84 (base `feat/better-v-form`), which carries #80 item 3 (Manufacturer ghost text). Merging this resolves all four #80 items.

Closes #80

## Test plan

- [x] tsc / lint / prettier clean
- [x] vitest 161/161
- [x] e2e no-auth chromium — 42 passed
- [x] live-Sobek name round-trip

🤖 Generated with [Claude Code](https://claude.com/claude-code)