### PR TITLE
vehicles: drop versionComment from VehicleTypes query

### DIFF
--- a/e2e-tests/fixtures/vehicle-types-mock.json
+++ b/e2e-tests/fixtures/vehicle-types-mock.json
@@ -14,10 +14,8 @@
           "created": null,
           "changed": null,
           "changedBy": null,
-          "versionComment": null,
           "deckPlan": {
             "id": "NMR:DeckPlan:1",
-            "description": "Single deck",
             "name": { "value": "Plan A" }
           },
           "vehicles": [{ "id": "NMR:Vehicle:101", "registrationNumber": "AA-101", "version": 1 }]
@@ -34,10 +32,8 @@
           "created": null,
           "changed": null,
           "changedBy": null,
-          "versionComment": null,
           "deckPlan": {
             "id": "NMR:DeckPlan:2",
-            "description": "Double deck",
             "name": { "value": "Plan B" }
           },
           "vehicles": [{ "id": "NMR:Vehicle:102", "registrationNumber": "BB-102", "version": 1 }]
@@ -54,10 +50,8 @@
           "created": null,
           "changed": null,
           "changedBy": null,
-          "versionComment": null,
           "deckPlan": {
             "id": "NMR:DeckPlan:3",
-            "description": "Articulated",
             "name": { "value": "Plan C" }
           },
           "vehicles": [{ "id": "NMR:Vehicle:103", "registrationNumber": "CC-103", "version": 1 }]

--- a/src/data/vehicle-types/vehicleTypeTypes.ts
+++ b/src/data/vehicle-types/vehicleTypeTypes.ts
@@ -27,7 +27,6 @@ export type VehicleType = {
   created?: string;
   changed?: string;
   changedBy?: string;
-  versionComment?: string;
   vehicles?: Vehicle[];
   __typename: string;
 };

--- a/src/graphql/vehicles/queries/fetchVehicleTypes.ts
+++ b/src/graphql/vehicles/queries/fetchVehicleTypes.ts
@@ -20,7 +20,6 @@ const fetchVehicleTypesGQL = gql`
         created
         changed
         changedBy
-        versionComment
         deckPlan {
           id
           name {


### PR DESCRIPTION
## Summary

- Sobek's `VehicleType` GraphQL type no longer exposes `versionComment` (confirmed via live introspection), so the `VehicleTypes` query failed schema validation against the real backend — the whole vehicle-types fetch errored.
- The field was requested and typed but never rendered in the UI.
- e2e never caught it: the Playwright mock returns canned JSON and doesn't validate the query against a schema.

Changes:
- `fetchVehicleTypes.ts` — drop `versionComment` from the query selection.
- `vehicleTypeTypes.ts` — drop `versionComment` from the `VehicleType` type.
- `vehicle-types-mock.json` — drop `versionComment` and the never-selected `deckPlan.description`, so the fixture mirrors the real response shape.

## Test plan

- [x] `tsc -b` clean
- [ ] Vehicle Types page loads against live Sobek (`npm run local`) — query no longer fails validation
- [ ] `npm run e2e:no-auth` green

> Note: a mock-based suite structurally can't catch this class of query/schema drift — a schema-validation test (validating query documents against the live/introspected schema) is a recommended follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)