### PR TITLE
fix(#96): sidebar FormLayout + container-query scale

### DIFF
--- a/FORK_DECISIONS.md
+++ b/FORK_DECISIONS.md
@@ -439,3 +439,45 @@ Concrete contract:
 - Theme integration of `--tm-*`.
 - Norway-variant `<symbol>` blocks.
 - Reuse on the existing `/vehicles` `TransportModeChip` cell.
+
+---
+
+## Drop `projection/` + `xml/` subdirs; adopt bulletproof-react segmentation _(2026-05-28)_
+
+### Context
+
+The 2026-05-16 split carved `src/data/vehicles/` into role-aligned subdirs (`projection/` for the GQL-read side, `xml/` for the NeTEx-write side). The read/write boundary it captured is real, but as a *naming convention for every feature* it's an ad-hoc one — and the project has since converged on bulletproof-react's per-feature segmentation as the house style.
+
+### Decision
+
+Every `src/data/<feature>/` follows bulletproof-react's sub-areas:
+
+```
+src/data/<feature>/
+  api/         — fetchers, mutations, GQL/REST adapters, NeTEx XML builders/parsers
+  assets/      — images/icons local to the feature
+  components/  — feature-only React components
+  hooks/       — feature-only hooks
+  stores/      — feature-only state (context/reducer)
+  types/       — feature-local types (incl. generated NeTEx + GQL projections)
+  utils/       — feature-only helpers
+```
+
+Omit any sub-area that's empty. The read/write semantics that motivated `projection/` and `xml/` are preserved by file/type naming (`*GqlShaped`, `Vehicle.ts` for NeTEx) and by JSDoc on the relevant `types/` files — not by directory name.
+
+### Supersedes
+
+- _Split `src/data/vehicles/` into `projection/` + `xml/`_ (2026-05-16). `projection/` collapses into `api/` + `types/`; `xml/` collapses into `api/` + `types/`.
+
+### Consequences
+
+- `vehicles/projection/*` → `vehicles/api/` (fetcher, hook) + `vehicles/types/` (`vehicleGqlShaped.ts`).
+- `vehicles/xml/*` → `vehicles/api/` (builder, save hook, parser) + `vehicles/types/` (generated `Vehicle.ts`, `VehicleModel.ts`, `*-mapping.ts`).
+- Bridge components at `vehicles/` root (`VehicleDetails`, `VehicleEditForm`, cells, etc.) move into `vehicles/components/`.
+- Cross-feature UI keeps living under `src/components/` (e.g. `src/components/FormLayout.tsx`) — bulletproof-react's segmentation is per-feature, not global.
+- Migration is incremental: rename when a feature is being touched anyway. No big-bang move; the ESLint netex-ts-gen exemption paths update with each carve.
+
+### Out of scope
+
+- An ESLint `no-restricted-imports` rule enforcing direction of cross-area imports inside a feature.
+- Renaming the existing `vehicle-types/`, `deck-plans/`, `vehicle-imports/` features pre-emptively — they get reshaped the next time they're touched.

--- a/src/components/FormLayout.tsx
+++ b/src/components/FormLayout.tsx
@@ -1,0 +1,120 @@
+import type { ReactNode } from 'react';
+import { Box, InputLabel, Typography } from '@mui/material';
+import type { SxProps, Theme } from '@mui/material/styles';
+
+const LABEL_COL_MAX = '12rem';
+const STACK_BELOW = '22rem';
+const COL_GAP = 2;
+const ROW_GAP = 1.25;
+
+interface FormLayoutProps {
+  children: ReactNode;
+  rowGap?: number;
+  sx?: SxProps<Theme>;
+  'data-testid'?: string;
+}
+
+/**
+ * Container-query-aware two-column form grid. Stacks (single column) when the
+ * nearest inline-size container is narrower than `STACK_BELOW`; otherwise
+ * renders label-column + value-column with a 12rem cap on the label.
+ *
+ * The wrapper sets `containerType: inline-size` on itself so the inner grid
+ * queries this component's own width — drop a `<FormLayout>` anywhere and it
+ * will track its host's width, not the viewport's.
+ *
+ * @param rowGap Override the default vertical row spacing (`1.25`).
+ * @param sx     Forwarded to the outer Box for caller-side spacing/margin.
+ */
+export function FormLayout({
+  children,
+  rowGap = ROW_GAP,
+  sx,
+  'data-testid': testId,
+}: FormLayoutProps) {
+  return (
+    <Box
+      data-testid={testId}
+      sx={
+        [
+          { containerType: 'inline-size', width: '100%' },
+          ...(Array.isArray(sx) ? sx : sx ? [sx] : []),
+        ] as SxProps<Theme>
+      }
+    >
+      <Box
+        sx={{
+          display: 'grid',
+          gridTemplateColumns: '1fr',
+          [`@container (min-width: ${STACK_BELOW})`]: {
+            gridTemplateColumns: `minmax(0, ${LABEL_COL_MAX}) 1fr`,
+          },
+          columnGap: COL_GAP,
+          rowGap,
+          alignItems: 'center',
+        }}
+      >
+        {children}
+      </Box>
+    </Box>
+  );
+}
+
+interface FieldRowProps {
+  id: string;
+  label: string;
+  alignTop?: boolean;
+  children: ReactNode;
+}
+
+/**
+ * Editable row inside {@link FormLayout}: an `<InputLabel htmlFor>` paired with
+ * a control. Uses `display: contents` so both halves become direct grid items
+ * of the parent — column alignment is owned by the parent grid, not the row.
+ *
+ * @param id       DOM id of the input the label points to (`htmlFor`).
+ * @param alignTop Pin the label to the top for multi-line controls.
+ */
+export function FieldRow({ id, label, alignTop, children }: FieldRowProps) {
+  return (
+    <Box sx={{ display: 'contents' }}>
+      <InputLabel
+        htmlFor={id}
+        sx={{
+          alignSelf: alignTop ? 'start' : 'center',
+          pt: alignTop ? 1 : 0,
+          mb: 0,
+          fontSize: '0.875rem',
+          color: 'text.primary',
+          whiteSpace: 'normal',
+          minWidth: 0,
+        }}
+      >
+        {label}
+      </InputLabel>
+      {children}
+    </Box>
+  );
+}
+
+interface MetaRowProps {
+  label: string;
+  children: ReactNode;
+}
+
+/**
+ * Read-only row inside {@link FormLayout}: a label `<Typography>` paired with
+ * a value node. Mirrors {@link FieldRow}'s `display: contents` pattern.
+ */
+export function MetaRow({ label, children }: MetaRowProps) {
+  return (
+    <Box sx={{ display: 'contents' }}>
+      <Typography sx={{ fontSize: '0.875rem', color: 'text.primary', minWidth: 0 }}>
+        {label}
+      </Typography>
+      <Typography variant="body2" component="div" sx={{ minWidth: 0 }}>
+        {children}
+      </Typography>
+    </Box>
+  );
+}

--- a/src/data/vehicles/VehicleDetails.tsx
+++ b/src/data/vehicles/VehicleDetails.tsx
@@ -1,13 +1,14 @@
-import { useEffect, useReducer, useState, type ReactNode } from 'react';
+import { useEffect, useReducer, useState } from 'react';
 import { Box, Divider, Stack, Typography } from '@mui/material';
 import { useTranslation } from 'react-i18next';
 import { useSearchParams } from 'react-router-dom';
 import NetexId from '../netex/NetexId.tsx';
 import TransportModeIcon from '../../components/icons/TransportModeIcon.tsx';
 import EditorRail from '../../components/sidebar/EditorRail.tsx';
+import { FormLayout, MetaRow } from '../../components/FormLayout.tsx';
 import { VEHICLE_SELECTED_PARAM } from './projection/vehicleUrlParams.ts';
 import { vehicleMode, type VehicleGQLShaped } from './projection/vehicleGqlShaped.ts';
-import VehicleEditForm, { LABEL_COL_MIN, LABEL_COL_MAX, COL_GAP } from './VehicleEditForm.tsx';
+import VehicleEditForm from './VehicleEditForm.tsx';
 import VehicleDetailsSkeleton from './VehicleDetailsSkeleton.tsx';
 import { firstText } from '../netex/multilingualString.ts';
 import SaveErrorSnackbar from './SaveErrorSnackbar.tsx';
@@ -122,19 +123,7 @@ export default function VehicleDetails({ vehicle, onSaved }: VehicleDetailsProps
 
   return (
     <Box sx={{ p: 2, height: '100%', overflowY: 'auto', boxSizing: 'border-box' }}>
-      <Box
-        sx={{
-          mb: 1,
-          width: '100%',
-          display: 'grid',
-          gridTemplateColumns: {
-            xs: '1fr',
-            sm: `minmax(${LABEL_COL_MIN}, ${LABEL_COL_MAX}) 1fr`,
-          },
-          columnGap: COL_GAP,
-          alignItems: 'center',
-        }}
-      >
+      <FormLayout sx={{ mb: 1 }}>
         <Typography
           variant="h6"
           noWrap
@@ -167,40 +156,22 @@ export default function VehicleDetails({ vehicle, onSaved }: VehicleDetailsProps
           size="small"
           sx={{ justifySelf: 'start' }}
         />
-      </Box>
+      </FormLayout>
       <Divider sx={{ mb: 2 }} />
 
-      <Box
-        sx={{
-          mb: 2,
-          width: '100%',
-          display: 'grid',
-          gridTemplateColumns: {
-            xs: '1fr',
-            sm: `minmax(${LABEL_COL_MIN}, ${LABEL_COL_MAX}) 1fr`,
-          },
-          columnGap: COL_GAP,
-          rowGap: 0.5,
-          alignItems: 'center',
-        }}
-        data-testid="vehicle-context"
-      >
-        <ContextRow
-          label={t('vehicles.field.parentVehicleType', 'Vehicle Type')}
-          value={
-            <Stack direction="row" spacing={1} alignItems="center" sx={{ flexWrap: 'wrap' }}>
-              <span>{vehicle.transportType?.name ?? '—'}</span>
-              {xmlVehicle?.TransportTypeRef && (
-                <NetexId id={xmlVehicle.TransportTypeRef} copy="only" size="medium" />
-              )}
-            </Stack>
-          }
-        />
-        <ContextRow
-          label={t('vehicles.field.parentTransportMode', 'Transport Mode')}
-          value={<TransportModeIcon mode={tmode} iconPosition="left" />}
-        />
-      </Box>
+      <FormLayout rowGap={0.5} sx={{ mb: 2 }} data-testid="vehicle-context">
+        <MetaRow label={t('vehicles.field.parentVehicleType', 'Vehicle Type')}>
+          <Stack direction="row" spacing={1} alignItems="center" sx={{ flexWrap: 'wrap' }}>
+            <span>{vehicle.transportType?.name ?? '—'}</span>
+            {xmlVehicle?.TransportTypeRef && (
+              <NetexId id={xmlVehicle.TransportTypeRef} copy="only" size="medium" />
+            )}
+          </Stack>
+        </MetaRow>
+        <MetaRow label={t('vehicles.field.parentTransportMode', 'Transport Mode')}>
+          <TransportModeIcon mode={tmode} iconPosition="left" />
+        </MetaRow>
+      </FormLayout>
       <Divider sx={{ mb: 2 }} />
 
       {xmlError ? (
@@ -240,15 +211,4 @@ type FormAction =
 
 function formReducer(state: FormState, action: FormAction): FormState {
   return action.type === 'hydrate' ? hydrate(state, action.xmlVehicle) : edit(state, action.form);
-}
-
-function ContextRow({ label, value }: { label: string; value: ReactNode }) {
-  return (
-    <Box sx={{ display: 'contents' }}>
-      <Typography sx={{ fontSize: '0.875rem', color: 'text.primary' }}>{label}</Typography>
-      <Typography variant="body2" component="div">
-        {value}
-      </Typography>
-    </Box>
-  );
 }

--- a/src/data/vehicles/VehicleDetailsSkeleton.tsx
+++ b/src/data/vehicles/VehicleDetailsSkeleton.tsx
@@ -1,6 +1,6 @@
 import { Box, Divider, Skeleton } from '@mui/material';
 import { useTranslation } from 'react-i18next';
-import { LABEL_COL_MIN, LABEL_COL_MAX, COL_GAP, ROW_GAP } from './VehicleEditForm.tsx';
+import { FormLayout } from '../../components/FormLayout.tsx';
 
 const CONTEXT_ROWS = 2;
 const VEHICLE_FORM_ROWS = 7;
@@ -13,22 +13,6 @@ const CONTEXT_VALUE_HEIGHT = 22;
 const CONTEXT_ROW_GAP = 0.5;
 const SECTION_HEADING_HEIGHT = 16;
 const ANIM = 'wave' as const;
-
-/**
- * Shared grid template used by every section so the skeleton lines up
- * column-for-column with the real {@link VehicleEditForm} that replaces it.
- * Keeps the swap from skeleton → form visually static (no layout shift).
- */
-const gridSx = {
-  width: '100%',
-  display: 'grid',
-  gridTemplateColumns: {
-    xs: '1fr',
-    sm: `minmax(${LABEL_COL_MIN}, ${LABEL_COL_MAX}) 1fr`,
-  },
-  columnGap: COL_GAP,
-  alignItems: 'center',
-};
 
 interface SkeletonRowProps {
   height?: number;
@@ -66,7 +50,7 @@ export default function VehicleDetailsSkeleton() {
       aria-label={t('vehicles.loading', 'Loading vehicle…')}
       sx={{ p: 2, height: '100%', overflowY: 'auto', boxSizing: 'border-box' }}
     >
-      <Box sx={{ ...gridSx, mb: 1 }}>
+      <FormLayout sx={{ mb: 1 }}>
         <Skeleton animation={ANIM} variant="text" height={TITLE_HEIGHT} width="70%" />
         <Skeleton
           animation={ANIM}
@@ -74,17 +58,17 @@ export default function VehicleDetailsSkeleton() {
           width={ID_PILL_WIDTH}
           height={ID_PILL_HEIGHT}
         />
-      </Box>
+      </FormLayout>
       <Divider sx={{ mb: 2 }} />
 
-      <Box sx={{ ...gridSx, mb: 2, rowGap: CONTEXT_ROW_GAP }}>
+      <FormLayout rowGap={CONTEXT_ROW_GAP} sx={{ mb: 2 }}>
         {contextRows.map((_, i) => (
           <SkeletonRow key={`ctx-${i}`} height={CONTEXT_VALUE_HEIGHT} />
         ))}
-      </Box>
+      </FormLayout>
       <Divider sx={{ mb: 2 }} />
 
-      <Box sx={{ ...gridSx, rowGap: ROW_GAP }}>
+      <FormLayout>
         {vehicleRows.map((_, i) => (
           <SkeletonRow key={`v-${i}`} />
         ))}
@@ -104,7 +88,7 @@ export default function VehicleDetailsSkeleton() {
         {modelRows.map((_, i) => (
           <SkeletonRow key={`m-${i}`} />
         ))}
-      </Box>
+      </FormLayout>
     </Box>
   );
 }

--- a/src/data/vehicles/VehicleEditForm.tsx
+++ b/src/data/vehicles/VehicleEditForm.tsx
@@ -1,16 +1,11 @@
-import type { ReactNode } from 'react';
-import { Box, InputLabel, TextField, Typography, Divider } from '@mui/material';
+import { TextField, Typography, Divider } from '@mui/material';
 import { useTranslation } from 'react-i18next';
 import type { Vehicle } from './xml/Vehicle';
 import type { VehicleModel } from './xml/VehicleModel';
 import { firstText } from '../netex/multilingualString.ts';
 import { MISSING_TEXT } from './vehicleFormDefaults';
 import { intToRef, refToInt } from './transportTypeRef';
-
-export const LABEL_COL_MIN = '8rem';
-export const LABEL_COL_MAX = '12rem';
-export const COL_GAP = 2;
-export const ROW_GAP = 1.25;
+import { FormLayout, FieldRow } from '../../components/FormLayout.tsx';
 
 export interface VehicleEditFormValue {
   vehicle: Vehicle;
@@ -28,40 +23,6 @@ const toTextArr = (s: string): { value: string }[] | undefined =>
 
 const orUndef = (s: string): string | undefined => (s.length === 0 ? undefined : s);
 
-interface FieldRowProps {
-  id: string;
-  label: string;
-  alignTop?: boolean;
-  children: ReactNode;
-}
-
-/**
- * Two-column form row using CSS Grid `display: contents` so the InputLabel
- * and the input become direct grid items of the parent grid. Keeps label↔input
- * pairing explicit in JSX while letting a single parent grid guarantee column
- * alignment across all rows.
- */
-function FieldRow({ id, label, alignTop, children }: FieldRowProps) {
-  return (
-    <Box sx={{ display: 'contents' }}>
-      <InputLabel
-        htmlFor={id}
-        sx={{
-          alignSelf: alignTop ? 'start' : 'center',
-          pt: alignTop ? 1 : 0,
-          mb: 0,
-          fontSize: '0.875rem',
-          color: 'text.primary',
-          whiteSpace: 'normal',
-        }}
-      >
-        {label}
-      </InputLabel>
-      {children}
-    </Box>
-  );
-}
-
 export default function VehicleEditForm({ value, onChange, mode }: VehicleEditFormProps) {
   const { t } = useTranslation();
   const v = value.vehicle;
@@ -78,15 +39,7 @@ export default function VehicleEditForm({ value, onChange, mode }: VehicleEditFo
   const rawTransportRef = transportRef !== '' && transportIntValue === '';
 
   return (
-    <Box
-      sx={{
-        display: 'grid',
-        gridTemplateColumns: { xs: '1fr', sm: `minmax(${LABEL_COL_MIN}, ${LABEL_COL_MAX}) 1fr` },
-        columnGap: COL_GAP,
-        rowGap: ROW_GAP,
-        alignItems: 'center',
-      }}
-    >
+    <FormLayout>
       <FieldRow id="vehicle-name" label={t('vehicles.field.name', 'Name')}>
         <TextField
           id="vehicle-name"
@@ -251,6 +204,6 @@ export default function VehicleEditForm({ value, onChange, mode }: VehicleEditFo
           fullWidth
         />
       </FieldRow>
-    </Box>
+    </FormLayout>
   );
 }


### PR DESCRIPTION
Closes #96.

## Summary

- Extracts the per-feature grid + row primitives from `VehicleEditForm` / `VehicleDetails` / `VehicleDetailsSkeleton` into a shared `src/components/FormLayout.tsx` (`FormLayout` + `FieldRow` + `MetaRow`) — addresses issue #96 part (1): DRY UI primitives ready for the next sidebar-edit consumer (`vehicleTypeView`).
- Swaps the viewport `sm` breakpoint for a `@container` query on the FormLayout's own outer Box (`containerType: inline-size`), and drops the 8rem label-column floor to `minmax(0, 12rem)` — addresses issue #96 part (2): when the sidebar resizer narrows the pane, the two columns now collapse to a single stacked column at the actual container width instead of staying wide just because the desktop viewport is wide.
- Appends an ADR to `FORK_DECISIONS.md` adopting bulletproof-react per-feature segmentation (`<feature>/{api,assets,components,hooks,stores,types,utils}/`), superseding the 2026-05-16 `projection/` + `xml/` split. The migration of `src/data/vehicles/` itself is a separate PR (see refactor/97).

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` — no new warnings
- [x] `npm run check` — prettier clean
- [x] `npm run build` — clean
- [x] `npm run e2e:no-auth` — 94 passed / 4 skipped (vehicle.spec.ts uses \`data-testid='vehicle-context'\` which now lives on the \`FormLayout\` outer Box)
- [x] `npm run e2e:auth` — 6 passed
- [ ] Manual: open \`/vehicles\`, click a vehicle, drag the resizer wide → narrow. Wide (≥ ~22rem inner): two-column layout, label capped at 12rem. Narrow (< ~22rem inner): rows stack — label above value — no overflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)