### PR TITLE
reveal e2e hang (GH) + rebuild tests to same coverage since XML-delete

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -14,6 +14,10 @@ jobs:
     # that hung and cancelled every run at the 60-min timeout.
     container:
       image: mcr.microsoft.com/playwright:v1.58.2-noble
+      # Firefox/WebKit sandbox via user namespaces (clone()), which the default
+      # container seccomp profile blocks → "CanCreateUserNamespace EPERM".
+      # Relax seccomp so Firefox can launch; Chromium is unaffected.
+      options: --security-opt seccomp=unconfined
     # Inside a container GitHub runs `run:` steps with `sh` (dash), which lacks
     # `set -o pipefail` used by the schema-guard. Force bash — present in the
     # image — to match host-runner behaviour.

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -8,6 +8,12 @@ jobs:
   test:
     timeout-minutes: 60
     runs-on: ubuntu-latest
+    # Browsers + OS deps come preinstalled in the official Playwright image,
+    # pinned to the @playwright/test version the e2e runner resolves to
+    # (1.58.2). This sidesteps the `npx playwright install` browser-download
+    # that hung and cancelled every run at the 60-min timeout.
+    container:
+      image: mcr.microsoft.com/playwright:v1.58.2-noble
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-node@v4
@@ -35,8 +41,6 @@ jobs:
           exit 1
         fi
         echo "Sobek schema in sync."
-    - name: Install Playwright Browsers
-      run: npx playwright install
     - name: Playwright auth ON
       run: npm run e2e:auth
     - name: Playwright auth OFF

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -36,7 +36,7 @@ jobs:
         fi
         echo "Sobek schema in sync."
     - name: Install Playwright Browsers
-      run: npx playwright install --with-deps
+      run: npx playwright install
     - name: Playwright auth ON
       run: npm run e2e:auth
     - name: Playwright auth OFF

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -53,10 +53,16 @@ jobs:
         echo "Sobek schema in sync."
     - name: Playwright auth ON
       run: npm run e2e:auth
+      # GH runs the container as root but sets HOME=/github/home (owned by the
+      # image's pwuser); Firefox refuses to run as root with a foreign HOME.
+      # Point HOME at a root-owned dir so Firefox launches.
+      env:
+        HOME: /root
     - name: Playwright auth OFF
       run: npm run e2e:no-auth
       env:
         E2E_BACKEND: 'false'
+        HOME: /root
     - uses: actions/upload-artifact@v4
       if: ${{ !cancelled() }}
       with:

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -14,6 +14,12 @@ jobs:
     # that hung and cancelled every run at the 60-min timeout.
     container:
       image: mcr.microsoft.com/playwright:v1.58.2-noble
+    # Inside a container GitHub runs `run:` steps with `sh` (dash), which lacks
+    # `set -o pipefail` used by the schema-guard. Force bash — present in the
+    # image — to match host-runner behaviour.
+    defaults:
+      run:
+        shell: bash
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-node@v4

--- a/e2e-tests/fixtures/config-no-baseurl.json
+++ b/e2e-tests/fixtures/config-no-baseurl.json
@@ -1,0 +1,8 @@
+{
+  "applicationGetAutosysUrl": "http://127.0.0.1:37998/services/autosys?registrationNumber=",
+  "applicationImportBaseUrl": "http://localhost:37999/services/vehicles/netex",
+  "applicationEnv": "test",
+  "claimsNamespace": "https://ror.entur.io/role_assignments",
+  "preferredNameNamespace": "https://ror.entur.io/preferred_name",
+  "themeFilePath": "/theme-dev.json"
+}

--- a/e2e-tests/fixtures/config-no-import-baseurl.json
+++ b/e2e-tests/fixtures/config-no-import-baseurl.json
@@ -1,8 +1,0 @@
-{
-  "applicationBaseUrl": "http://localhost:37999/services/vehicles/graphql",
-  "applicationGetAutosysUrl": "http://127.0.0.1:37998/services/autosys?registrationNumber=",
-  "applicationEnv": "test",
-  "claimsNamespace": "https://ror.entur.io/role_assignments",
-  "preferredNameNamespace": "https://ror.entur.io/preferred_name",
-  "themeFilePath": "/theme-dev.json"
-}

--- a/e2e-tests/no-auth/vehicle-create-feedback.spec.ts
+++ b/e2e-tests/no-auth/vehicle-create-feedback.spec.ts
@@ -4,8 +4,9 @@ import * as path from 'path';
 import { fileURLToPath } from 'url';
 import {
   interceptStatefulVehicleListQuery,
-  interceptVehicleNetexGet,
-  vehiclePublicationDelivery,
+  interceptVehicleByIdQuery,
+  interceptVehicleSaveMutation,
+  vehicleRow,
 } from './vehicle-list-helpers';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -38,26 +39,21 @@ test.describe('/vehicles/new save feedback + redirect (no-auth)', () => {
     fs.copyFileSync(path.join(fixturesDir, 'config-no-auth.json'), targetConfig);
   });
 
-  /** Wires the stateful list + POST + single-vehicle GET. `lag` = list calls
-   *  that still return baseline after the import POST resolves. Mirrors real
-   *  Sobek behaviour: a POST without `<TransportTypeRef/>` persists but stays
-   *  invisible to the GraphQL `vehicles()` resolver (probe 2026-05-19) — so
-   *  the mock only flips `addCreated` when the payload carries the ref. */
+  /** Wires the stateful list + `createOrUpdateVehicle` mutation + single-vehicle
+   *  by-id fetch. `lag` = list calls that still return baseline after the save
+   *  mutation resolves. Mirrors real Sobek behaviour: a save without a real
+   *  `transportType.netexId` persists but stays invisible to the GraphQL
+   *  `vehicles()` resolver (probe 2026-05-19) — so the mock only flips
+   *  `addCreated` when the mutation input carries a numeric VehicleType ref. */
   const wireCreateFlow = async (page: Page, { lag = 0 } = {}) => {
     if (process.env.E2E_BACKEND === 'true') return null;
     const list = await interceptStatefulVehicleListQuery(page);
-    await interceptVehicleNetexGet(page);
-    await page.route('**/services/vehicles/netex', async route => {
-      if (route.request().method() !== 'POST') return route.continue();
-      const body = route.request().postData() ?? '';
-      if (/<TransportTypeRef\s+ref="NMR:VehicleType:\d+"/.test(body)) {
-        list.addCreated(NEW_ID, lag);
-      }
-      await route.fulfill({
-        status: 200,
-        contentType: 'application/xml',
-        body: vehiclePublicationDelivery(NEW_ID),
-      });
+    await interceptVehicleByIdQuery(page, id =>
+      id === NEW_ID ? vehicleRow(id, { name: { value: 'Newly created' } }) : null
+    );
+    interceptVehicleSaveMutation(page, NEW_ID, input => {
+      const ref = (input.transportType as { netexId?: string } | undefined)?.netexId;
+      if (ref && /^NMR:VehicleType:\d+$/.test(ref)) list.addCreated(NEW_ID, lag);
     });
     return list;
   };

--- a/e2e-tests/no-auth/vehicle-create-form.spec.ts
+++ b/e2e-tests/no-auth/vehicle-create-form.spec.ts
@@ -4,8 +4,9 @@ import * as path from 'path';
 import { fileURLToPath } from 'url';
 import {
   interceptStatefulVehicleListQuery,
-  interceptVehicleNetexGet,
-  vehiclePublicationDelivery,
+  interceptVehicleByIdQuery,
+  interceptVehicleSaveMutation,
+  vehicleRow,
 } from './vehicle-list-helpers';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -17,46 +18,38 @@ const targetConfig = path.join(__dirname, '..', '..', 'public', 'config.json');
 const NEW_ID = 'NMR:Vehicle:NEW-1';
 const VT_ID_INT = '2';
 const EXPECTED_REF = `NMR:VehicleType:${VT_ID_INT}`;
-const TRANSPORT_REF_PATTERN = /<TransportTypeRef\s+ref="NMR:VehicleType:\d+"/;
+const REF_PATTERN = /^NMR:VehicleType:\d+$/;
 
 /**
- * Regression coverage for the three coupled VehicleEditForm edits:
- *   - #80 sect3 — Manufacturer ghost text (no [missing] literal in payload)
+ * Regression coverage for the coupled VehicleEditForm edits, realigned to the
+ * GraphQL save path after #101 retired the NeTEx-XML import POST:
  *   - #82 — TransportType field required + writable
  *   - #81 — Back button on /vehicles/new with dirty-form discard dialog
  *
  * The TransportType field is a TEMP bare numeric input until Sobek's
  * VehicleTypeFilter gains a `name` field. The onChange prefixes
  * `NMR:VehicleType:` before binding to form state — this spec asserts on the
- * full prefixed shape in the POST body.
+ * full prefixed shape in the `createOrUpdateVehicle` mutation input.
  */
 test.describe('/vehicles/new form gates + back nav (no-auth)', () => {
   test.beforeAll(() => {
     fs.copyFileSync(path.join(fixturesDir, 'config-no-auth.json'), targetConfig);
   });
 
-  /** Captures the most recent NeTEx-import POST body so specs can assert
-   *  on its shape (e.g. presence/absence of <TransportTypeRef>, <Manufacturer>). */
+  /** Captures the most recent `createOrUpdateVehicle` mutation input so specs
+   *  can assert on its shape (e.g. the prefixed `transportType.netexId`). */
   const wireCreateFlow = async (page: Page) => {
-    if (process.env.E2E_BACKEND === 'true') return { postBody: () => '' };
+    if (process.env.E2E_BACKEND === 'true') return { input: () => null };
     const list = await interceptStatefulVehicleListQuery(page);
-    await interceptVehicleNetexGet(page);
-    let lastPostBody = '';
-    await page.route('**/services/vehicles/netex', async route => {
-      if (route.request().method() !== 'POST') return route.continue();
-      lastPostBody = route.request().postData() ?? '';
+    await interceptVehicleByIdQuery(page, id => (id === NEW_ID ? vehicleRow(id) : null));
+    return interceptVehicleSaveMutation(page, NEW_ID, input => {
       // Gate-equivalent: only "persist" when the client included a real ref.
-      if (TRANSPORT_REF_PATTERN.test(lastPostBody)) list.addCreated(NEW_ID, 0);
-      await route.fulfill({
-        status: 200,
-        contentType: 'application/xml',
-        body: vehiclePublicationDelivery(NEW_ID),
-      });
+      const ref = (input.transportType as { netexId?: string } | undefined)?.netexId;
+      if (ref && REF_PATTERN.test(ref)) list.addCreated(NEW_ID, 0);
     });
-    return { postBody: () => lastPostBody };
   };
 
-  test('Save disabled until Vehicle Type ID entered; POST body carries prefixed TransportTypeRef', async ({
+  test('Save disabled until Vehicle Type ID entered; mutation input carries prefixed transportType ref', async ({
     page,
   }) => {
     const capture = await wireCreateFlow(page);
@@ -73,25 +66,8 @@ test.describe('/vehicles/new form gates + back nav (no-auth)', () => {
 
     await save.click();
     await expect(page.getByRole('button', { name: 'View in list' })).toBeVisible();
-    expect(capture.postBody()).toContain(`<TransportTypeRef ref="${EXPECTED_REF}"`);
-    expect(capture.postBody()).toMatch(TRANSPORT_REF_PATTERN);
-  });
-
-  test('Manufacturer field: value empty, placeholder [missing] (no payload literal)', async ({
-    page,
-  }) => {
-    // Open existing vehicle slider so MISSING_MODEL applies (Sobek single-vehicle
-    // export emits no Model — the form's model slot defaults to MISSING_MODEL).
-    await wireCreateFlow(page);
-    await page.goto(`/vehicles?selected=${encodeURIComponent('NMR:Vehicle:bus-1')}`);
-    await page.waitForLoadState('networkidle');
-    await expect(page.getByTestId('vehicle-details-title')).toBeVisible();
-
-    await page.getByTestId('editor-rail-edit').click();
-
-    const manufacturer = page.getByLabel('Manufacturer');
-    await expect(manufacturer).toHaveValue('');
-    await expect(manufacturer).toHaveAttribute('placeholder', '[missing]');
+    const input = capture.input() as { transportType?: { netexId?: string } } | null;
+    expect(input?.transportType?.netexId).toBe(EXPECTED_REF);
   });
 
   test('Back button: clean form navigates immediately to /vehicles', async ({ page }) => {
@@ -158,15 +134,11 @@ test.describe('/vehicles/new form gates + back nav (no-auth)', () => {
     const vehicleId = 'NMR:Vehicle:rail-1';
     const rawRef = 'NMR:VehicleType:rail';
     await interceptStatefulVehicleListQuery(page);
-    await page.route('**/services/vehicles/netex/vehicles/**', async route => {
-      if (route.request().method() !== 'GET') return route.continue();
-      const id = decodeURIComponent(new URL(route.request().url()).pathname.split('/').pop() ?? '');
-      await route.fulfill({
-        status: 200,
-        contentType: 'application/xml',
-        body: vehiclePublicationDelivery(id, `<TransportTypeRef ref="${rawRef}"/>`),
-      });
-    });
+    await interceptVehicleByIdQuery(page, id =>
+      vehicleRow(id, {
+        transportType: { netexId: rawRef, version: 1, name: null, transportMode: 'rail' },
+      })
+    );
 
     await page.goto(`/vehicles?selected=${encodeURIComponent(vehicleId)}`);
     await page.waitForLoadState('networkidle');

--- a/e2e-tests/no-auth/vehicle-list-helpers.ts
+++ b/e2e-tests/no-auth/vehicle-list-helpers.ts
@@ -38,7 +38,10 @@ export const interceptVehicleListQuery = (page: Page) =>
         body: JSON.stringify(MOCK_VEHICLES_LIST),
       });
     } else {
-      await route.continue();
+      // Fall through to any handler registered earlier (by-id query, save
+      // mutation) rather than straight to the network — `page.route` runs
+      // handlers in reverse registration order and `fallback()` chains them.
+      await route.fallback();
     }
   });
 
@@ -64,8 +67,12 @@ export const interceptStatefulVehicleListQuery = async (page: Page) => {
   await page.route('**/graphql', async route => {
     const postData = route.request().postDataJSON();
     const query: string = postData?.query ?? '';
-    if (!query.includes('vehicles(')) {
-      await route.continue();
+    // Only the unfiltered *list* query is this handler's concern. A
+    // `filter.netexIds` query is a single-vehicle fetch — let the by-id
+    // handler answer it; the save mutation likewise belongs elsewhere.
+    const netexIds: string[] | undefined = postData?.variables?.filter?.netexIds;
+    if (!query.includes('vehicles(') || netexIds) {
+      await route.fallback();
       return;
     }
     state.callCount += 1;
@@ -102,78 +109,131 @@ export const interceptStatefulVehicleListQuery = async (page: Page) => {
   };
 };
 
-const makeExtraVehicle = (id: string) => ({
+const makeExtraVehicle = (id: string) =>
+  vehicleRow(id, {
+    name: { value: 'Newly created' },
+    registrationNumber: 'NEW-001',
+    transportType: {
+      netexId: 'NMR:VehicleType:bus',
+      version: 1,
+      name: { value: 'Bus Type' },
+      transportMode: 'bus',
+    },
+  });
+
+/** A single-vehicle GraphQL row. Mirrors the `vehicles(...)` selection in
+ *  `src/graphql/vehicles/queries/fetchVehicles.ts` field-for-field so the mock
+ *  exercises `fetchVehicle`'s projection against the real wire shape. All
+ *  nullable fields default to null; override per test via {@link vehicleRow}. */
+export interface VehicleRow {
+  netexId: string;
+  version: number;
+  name: { value: string } | null;
+  registrationNumber: string;
+  operationalNumber: string | null;
+  buildDate: string | null;
+  chassisNumber: string | null;
+  description: { value: string } | null;
+  registrationDate: string | null;
+  transportType: {
+    netexId: string;
+    version: number;
+    name: { value: string } | null;
+    transportMode: string | null;
+  } | null;
+}
+
+/** Build a full single-vehicle row for `id`, with `over` patching any field.
+ *  Defaults to a rail vehicle so the row is renderable without every test
+ *  re-stating the common fields. */
+export const vehicleRow = (id: string, over: Partial<VehicleRow> = {}): VehicleRow => ({
   netexId: id,
   version: 1,
-  registrationNumber: 'NEW-001',
+  name: null,
+  registrationNumber: 'REG-001',
   operationalNumber: null,
+  buildDate: null,
+  chassisNumber: null,
+  description: null,
+  registrationDate: null,
   transportType: {
-    netexId: 'NMR:VehicleType:bus',
+    netexId: 'NMR:VehicleType:rail',
     version: 1,
-    name: { value: 'Bus Type' },
-    transportMode: 'bus',
+    name: { value: 'Rail Type' },
+    transportMode: 'rail',
   },
+  ...over,
 });
 
-/** Sobek wraps every multilingual value in a nested `<Text>` element —
- *  `<Name><Text>…</Text></Name>` (confirmed via live probe). Mirror that exact
- *  shape in mocks so the parser is exercised against reality rather than a
- *  friendlier invented `<Name>value</Name>` shape that masks round-trip bugs. */
-export const netexName = (value: string) => `<Name><Text>${value}</Text></Name>`;
-
-/** Minimal PublicationDelivery wrapping a single Vehicle. `body` is inserted
- *  inside the `<Vehicle>` element — leave empty for a bare echo, or pass
- *  e.g. `${netexName('X')}<RegistrationNumber>R</RegistrationNumber>`. */
-export const vehiclePublicationDelivery = (id: string, body = '') =>
-  `<?xml version="1.0" encoding="UTF-8"?>
-<PublicationDelivery xmlns="http://www.netex.org.uk/netex">
-  <dataObjects>
-    <ResourceFrame>
-      <vehicles>
-        <Vehicle id="${id}" version="1">${body}</Vehicle>
-      </vehicles>
-    </ResourceFrame>
-  </dataObjects>
-</PublicationDelivery>`;
-
 /**
- * Intercept POST to the NeTEx import endpoint and return a PublicationDelivery
- * containing a Vehicle with the given id. `parseVehicleImportResponse` then
- * extracts this id as `result.newId`.
+ * Intercept the single-vehicle GraphQL fetch — a `vehicles(...)` query carrying
+ * a `filter.netexIds` — and answer it from `resolve(id)`. This is the GraphQL
+ * replacement for the retired NeTEx-XML single-vehicle GET: production
+ * `useVehicle` now reads `fetchVehicle` → `vehicles(filter:{netexIds:[id]})`.
+ *
+ * `resolve` returns the row to serve, or `null` to model "not found" (empty
+ * `content`, which surfaces as `useVehicle`'s not-found error). Unfiltered
+ * list queries and the save mutation fall through to their own handlers.
+ *
+ * Register AFTER the list interceptor so it is checked first and only claims
+ * the filtered query.
  */
-export const interceptVehicleImportPost = (page: Page, newId: string) =>
-  page.route('**/services/vehicles/netex', async route => {
-    if (route.request().method() !== 'POST') {
-      await route.continue();
+export const interceptVehicleByIdQuery = (page: Page, resolve: (id: string) => VehicleRow | null) =>
+  page.route('**/graphql', async route => {
+    const postData = route.request().postDataJSON();
+    const query: string = postData?.query ?? '';
+    const netexIds: string[] | undefined = postData?.variables?.filter?.netexIds;
+    if (!query.includes('vehicles(') || !netexIds?.length) {
+      await route.fallback();
       return;
     }
+    const row = resolve(netexIds[0]);
     await route.fulfill({
       status: 200,
-      contentType: 'application/xml',
-      body: vehiclePublicationDelivery(newId),
+      contentType: 'application/json',
+      body: JSON.stringify({
+        data: {
+          vehicles: {
+            content: row ? [row] : [],
+            totalElements: row ? 1 : 0,
+            page: 0,
+            size: 10000,
+          },
+        },
+      }),
     });
   });
 
 /**
- * Intercept GET on the single-vehicle NeTEx XML endpoint
- * (`/services/vehicles/netex/vehicles/{id}`) and return a minimal but valid
- * Vehicle PublicationDelivery for the requested id. Used so the slider's
- * `useVehicle` hook resolves to a parsed Vehicle (not "Vehicle not found").
+ * Intercept the `createOrUpdateVehicle` mutation — the GraphQL replacement for
+ * the retired NeTEx-XML import POST. Captures the mutation's `input` for
+ * assertions, invokes `onSaved(input)` (e.g. to flip a stateful list's
+ * `addCreated`), and returns `newId` as the mutation's scalar result so
+ * `useVehiclePairSave` surfaces it as `result.newId`.
+ *
+ * Register AFTER the list/by-id interceptors. Non-mutation operations fall
+ * through.
  */
-export const interceptVehicleNetexGet = (page: Page) =>
-  page.route('**/services/vehicles/netex/vehicles/**', async route => {
-    if (route.request().method() !== 'GET') {
-      await route.continue();
+export const interceptVehicleSaveMutation = (
+  page: Page,
+  newId: string,
+  onSaved?: (input: Record<string, unknown>) => void
+) => {
+  const state = { lastInput: null as Record<string, unknown> | null };
+  page.route('**/graphql', async route => {
+    const postData = route.request().postDataJSON();
+    const query: string = postData?.query ?? '';
+    if (!query.includes('createOrUpdateVehicle')) {
+      await route.fallback();
       return;
     }
-    const url = new URL(route.request().url());
-    const id = decodeURIComponent(url.pathname.split('/').pop() ?? '');
+    state.lastInput = postData?.variables?.input ?? null;
+    onSaved?.(state.lastInput ?? {});
     await route.fulfill({
       status: 200,
-      contentType: 'application/xml',
-      body: vehiclePublicationDelivery(
-        id,
-        `${netexName('Newly created')}<RegistrationNumber>NEW-001</RegistrationNumber>`
-      ),
+      contentType: 'application/json',
+      body: JSON.stringify({ data: { createOrUpdateVehicle: newId } }),
     });
   });
+  return { input: () => state.lastInput };
+};

--- a/e2e-tests/no-auth/vehicle-list-helpers.ts
+++ b/e2e-tests/no-auth/vehicle-list-helpers.ts
@@ -20,18 +20,22 @@ const MOCK_VEHICLES_LIST: unknown = JSON.parse(
 );
 
 /**
- * Intercept the GraphQL `vehicles(...)` query and return the vehicles-list
- * fixture. Other GraphQL operations on the same endpoint pass through.
+ * Intercept the unfiltered GraphQL `vehicles(...)` list query and return the
+ * vehicles-list fixture. Other GraphQL operations pass through.
  *
  * Matches on the field name `vehicles(` (not on a token like `vehicleTypes`)
  * so the matcher survives query-shape changes that keep the field name
- * stable but rename surrounding operation names.
+ * stable but rename surrounding operation names. A `filter.netexIds` query is
+ * a *single-vehicle* fetch — this handler falls through on it (symmetric with
+ * {@link interceptStatefulVehicleListQuery}) so it stays safe to register
+ * standalone: it never answers a by-id fetch with the full list.
  */
 export const interceptVehicleListQuery = (page: Page) =>
   page.route('**/graphql', async route => {
     const postData = route.request().postDataJSON();
     const query: string = postData?.query ?? '';
-    if (query.includes('vehicles(')) {
+    const netexIds: string[] | undefined = postData?.variables?.filter?.netexIds;
+    if (query.includes('vehicles(') && !netexIds) {
       await route.fulfill({
         status: 200,
         contentType: 'application/json',
@@ -46,23 +50,30 @@ export const interceptVehicleListQuery = (page: Page) =>
   });
 
 /**
+ * Resolve a single vehicle from the list fixture by NeTEx id — the faithful
+ * by-id resolver for specs that deep-link into the slider on a row that exists
+ * in {@link interceptVehicleListQuery}'s dataset. Returns `null` for an unknown
+ * id (modelling not-found). Pass straight to {@link interceptVehicleByIdQuery}.
+ */
+export const mockVehicleById = (id: string): VehicleRow | null => {
+  const list = MOCK_VEHICLES_LIST as { data: { vehicles: { content: VehicleRow[] } } };
+  return list.data.vehicles.content.find(v => v.netexId === id) ?? null;
+};
+
+/**
  * Stateful vehicles list interceptor used by create-flow specs. The baseline
  * 15-row fixture is returned until `addCreated(id)` is called with a positive
  * `lagCalls` — for the next `lagCalls` GraphQL list responses the new id is
  * **still missing** (read-after-write replica lag), and from then on every
  * response includes it. `lagCalls = 0` (the default) makes the row available
- * immediately. `bumpVersion(id)` increments an existing row's `version` from
- * the next response onward — mirrors a real backend bumping the persisted
- * row's version on save, which the non-stateful interceptor cannot reproduce
- * (its byte-identical refetch masks the `rowSig` re-commit in slider edits).
- * Tracks every `vehicles(` request count so specs can assert on extra fetches.
+ * immediately. Tracks every `vehicles(` request count so specs can assert on
+ * extra fetches.
  */
 export const interceptStatefulVehicleListQuery = async (page: Page) => {
   const state = {
     extraId: null as string | null,
     lagCalls: 0,
     callCount: 0,
-    bumpId: null as string | null,
   };
   await page.route('**/graphql', async route => {
     const postData = route.request().postDataJSON();
@@ -80,16 +91,12 @@ export const interceptStatefulVehicleListQuery = async (page: Page) => {
     if (state.lagCalls > 0) state.lagCalls -= 1;
     const base = JSON.parse(JSON.stringify(MOCK_VEHICLES_LIST)) as {
       data: {
-        vehicles: { content: { netexId?: string; version?: number }[]; totalElements: number };
+        vehicles: { content: { netexId?: string }[]; totalElements: number };
       };
     };
     if (includeExtra && state.extraId) {
       base.data.vehicles.content.push(makeExtraVehicle(state.extraId));
       base.data.vehicles.totalElements = base.data.vehicles.content.length;
-    }
-    if (state.bumpId) {
-      const row = base.data.vehicles.content.find(r => r.netexId === state.bumpId);
-      if (row && typeof row.version === 'number') row.version += 1;
     }
     await route.fulfill({
       status: 200,
@@ -101,9 +108,6 @@ export const interceptStatefulVehicleListQuery = async (page: Page) => {
     addCreated: (id: string, lagCalls = 0) => {
       state.extraId = id;
       state.lagCalls = lagCalls;
-    },
-    bumpVersion: (id: string) => {
-      state.bumpId = id;
     },
     callCount: () => state.callCount,
   };

--- a/e2e-tests/no-auth/vehicle-loading-state.spec.ts
+++ b/e2e-tests/no-auth/vehicle-loading-state.spec.ts
@@ -2,6 +2,7 @@ import { test, expect } from '@playwright/test';
 import * as fs from 'fs';
 import * as path from 'path';
 import { fileURLToPath } from 'url';
+import { interceptVehicleByIdQuery, vehicleRow } from './vehicle-list-helpers';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -9,38 +10,37 @@ const __dirname = path.dirname(__filename);
 const fixturesDir = path.join(__dirname, '..', 'fixtures');
 const targetConfig = path.join(__dirname, '..', '..', 'public', 'config.json');
 
-const MISSING_BASE_URL_ERROR = 'Application import base URL is not configured';
+const SELECTED_ID = 'NMR:Vehicle:bus-1';
+const NOT_FOUND_ERROR = `Vehicle "${SELECTED_ID}" not found`;
 
 /**
- * Regression test for B1 (PR #74 review): when `applicationImportBaseUrl`
- * is missing from runtime config, `useVehicle` must short-circuit into
- * `loading=false` + a user-visible error — *not* hang forever on the
- * "Loading vehicle…" spinner.
+ * Regression test for B1 (PR #74 review): `useVehicle` must never hang on the
+ * "Loading vehicle…" spinner — it must resolve `loading=false` and surface a
+ * user-visible error.
  *
- * Before fix: `useVehicle.doFetch` returned early without
- * `setLoading(false)`. Initial `useState(!!id)` left loading=true forever
- * when id was truthy.
- *
- * After fix: missing-baseUrl branch sets `error` and `loading=false`
- * synchronously, surfacing the same message
- * `useVehiclePairSave` already emits for the save path.
+ * Realigned to the GraphQL read path after #101 retired the NeTEx-XML single
+ * fetch. The obsolete trigger (missing `applicationImportBaseUrl`) no longer
+ * applies: `useVehicle` now reads `applicationBaseUrl`, shared with the list,
+ * so a missing-config scenario can't isolate the slider. The surviving
+ * equivalent — a `vehicles(filter:{netexIds})` fetch that resolves to no row —
+ * is exercised here: the list query still returns the row (so the slider opens
+ * with a title), while the single-vehicle query returns empty `content`,
+ * driving `useVehicle` into its not-found error branch.
  */
-test.describe('useVehicle — missing applicationImportBaseUrl never stops loading (no-auth)', () => {
+test.describe('useVehicle — a single-vehicle fetch with no match errors, never hangs (no-auth)', () => {
   test.beforeAll(() => {
-    fs.copyFileSync(path.join(fixturesDir, 'config-no-import-baseurl.json'), targetConfig);
-  });
-
-  test.afterAll(() => {
     fs.copyFileSync(path.join(fixturesDir, 'config-no-auth.json'), targetConfig);
   });
 
   test.beforeEach(async ({ page }) => {
     if (process.env.E2E_BACKEND === 'true') return;
 
+    // List query (no `filter.netexIds`) → the row exists, so the slider opens
+    // on a found row and renders a title.
     await page.route('**/graphql', async route => {
       const body = route.request().postDataJSON();
       const q: string = body?.query ?? '';
-      if (q.includes('vehicles(')) {
+      if (q.includes('vehicles(') && !body?.variables?.filter?.netexIds) {
         await route.fulfill({
           status: 200,
           contentType: 'application/json',
@@ -48,18 +48,15 @@ test.describe('useVehicle — missing applicationImportBaseUrl never stops loadi
             data: {
               vehicles: {
                 content: [
-                  {
-                    netexId: 'NMR:Vehicle:bus-1',
-                    version: 1,
+                  vehicleRow(SELECTED_ID, {
                     registrationNumber: 'BUS-001',
-                    operationalNumber: null,
                     transportType: {
                       netexId: 'NMR:VehicleType:bus',
                       version: 1,
                       name: { value: 'Bus Type' },
                       transportMode: 'bus',
                     },
-                  },
+                  }),
                 ],
                 totalElements: 1,
                 page: 0,
@@ -69,26 +66,30 @@ test.describe('useVehicle — missing applicationImportBaseUrl never stops loadi
           }),
         });
       } else {
-        await route.continue();
+        await route.fallback();
       }
     });
+
+    // Single-vehicle query (with `filter.netexIds`) → empty content → not found.
+    await interceptVehicleByIdQuery(page, () => null);
   });
 
-  test('missing import baseUrl surfaces as an error, not a stuck spinner', async ({ page }) => {
-    await page.goto('/vehicles?selected=NMR:Vehicle:bus-1');
+  test('a single-vehicle fetch that returns no row surfaces an error, not a stuck spinner', async ({
+    page,
+  }) => {
+    await page.goto(`/vehicles?selected=${SELECTED_ID}`);
     await page.waitForLoadState('networkidle');
 
     await expect(page.getByTestId('vehicle-details-title')).toBeVisible();
 
-    // Loading resolves quickly — the missing-baseUrl branch should set
-    // error + loading=false synchronously, so the spinner is gone almost
-    // immediately. Auto-wait to its default disappearance timeout.
+    // Loading resolves — the not-found branch sets error + loading=false, so
+    // the spinner disappears. Auto-wait to its default disappearance timeout.
     await expect(page.getByText('Loading vehicle…')).toBeHidden();
 
-    // User sees the actual reason, mirroring useVehiclePairSave's message.
-    await expect(page.getByText(MISSING_BASE_URL_ERROR)).toBeVisible();
+    // User sees the actual reason.
+    await expect(page.getByText(NOT_FOUND_ERROR)).toBeVisible();
 
-    // Form area stays hidden because xmlError is set.
+    // Form area stays hidden because the fetch errored.
     await expect(page.locator('#vehicle-registration-number')).toHaveCount(0);
   });
 });

--- a/e2e-tests/no-auth/vehicle-loading-state.spec.ts
+++ b/e2e-tests/no-auth/vehicle-loading-state.spec.ts
@@ -93,3 +93,42 @@ test.describe('useVehicle — a single-vehicle fetch with no match errors, never
     await expect(page.locator('#vehicle-registration-number')).toHaveCount(0);
   });
 });
+
+const MISSING_BASE_URL_ERROR = 'Application base URL is not configured';
+
+/**
+ * Restores coverage of the PR #74 B1 invariant — a missing `applicationBaseUrl`
+ * must surface a user-visible error, never fail silently. `useVehicle`'s copy
+ * of this guard can't be isolated end-to-end (it shares the key with the list
+ * hook, which simply renders no rows when the key is absent), but its sibling
+ * in `useVehiclePairSave` is reachable: `/vehicles/new` renders the form with
+ * no list, so a save with no base URL drives the guard directly.
+ */
+test.describe('save with no applicationBaseUrl surfaces a config error, not silent failure (no-auth)', () => {
+  test.skip(process.env.E2E_BACKEND === 'true', 'mock-only — drives a deliberately broken config');
+
+  test.beforeAll(() => {
+    fs.copyFileSync(path.join(fixturesDir, 'config-no-baseurl.json'), targetConfig);
+  });
+
+  test.afterAll(() => {
+    fs.copyFileSync(path.join(fixturesDir, 'config-no-auth.json'), targetConfig);
+  });
+
+  test('saving a new vehicle with no base URL shows the config error and does not navigate', async ({
+    page,
+  }) => {
+    await page.goto('/vehicles/new');
+    await page.waitForLoadState('networkidle');
+
+    await page.getByLabel('Registration Number').fill('NEW-001');
+    await page.getByLabel(/Vehicle Type ID/).fill('2');
+    await page.getByRole('button', { name: 'Save' }).click();
+
+    // The guard short-circuits before any request: error snackbar, no success
+    // action, still on /vehicles/new.
+    await expect(page.getByText(MISSING_BASE_URL_ERROR)).toBeVisible();
+    await expect(page.getByRole('button', { name: 'View in list' })).toHaveCount(0);
+    await expect(page).toHaveURL(/\/vehicles\/new$/);
+  });
+});

--- a/e2e-tests/no-auth/vehicle-slider-form.spec.ts
+++ b/e2e-tests/no-auth/vehicle-slider-form.spec.ts
@@ -1,12 +1,13 @@
-import { test, expect, type Page } from '@playwright/test';
+import { test, expect } from '@playwright/test';
 import * as fs from 'fs';
 import * as path from 'path';
 import { fileURLToPath } from 'url';
 import {
   interceptVehicleListQuery,
   interceptStatefulVehicleListQuery,
-  netexName,
-  vehiclePublicationDelivery,
+  interceptVehicleByIdQuery,
+  interceptVehicleSaveMutation,
+  vehicleRow,
 } from './vehicle-list-helpers';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -19,45 +20,32 @@ const VEHICLE_ID = 'NMR:Vehicle:rail-1';
 const SELECTED = `/vehicles?selected=${encodeURIComponent(VEHICLE_ID)}`;
 
 /**
- * Regression coverage for the three remaining bugs in hathor #80:
+ * Regression coverage for the remaining bugs in hathor #80, realigned to the
+ * GraphQL read/save paths after #101 retired the NeTEx-XML single-vehicle
+ * fetch:
  *
- *   1. Vehicle Name renders blank — Sobek's exporter wraps the value in a
- *      nested <Text> element (`<Name><Text>Foo</Text></Name>`), a shape
- *      `projectText` did not unwrap, so the value was silently dropped.
- *   2. Build/Registration dates were plain text inputs with no picker.
- *   4. After a successful save the dirty baseline was never advanced (the
- *      single-vehicle XML was not refetched), so closing the slider with
- *      `>>` wrongly raised the discard dialog.
+ *   1. Vehicle Name renders in title + form field — now sourced from the
+ *      `vehicles(filter:{netexIds})` `name.value`, the shape `useVehicle`
+ *      consumes via `fetchVehicle`.
+ *   2. Build/Registration dates render as native date pickers bound to the
+ *      fetched value.
+ *   4. After a successful save the dirty baseline advances (the single-vehicle
+ *      refetch re-hydrates the form), so closing the slider with `>>` does not
+ *      wrongly raise the discard dialog.
  *
  * Mock-only — the asserted Name/date values are fixture-controlled, so this
  * spec is meaningless against a live backend.
  */
-test.describe('/vehicles slider form — parsing + post-save dirty baseline (no-auth)', () => {
+test.describe('/vehicles slider form — fetch + post-save dirty baseline (no-auth)', () => {
   test.skip(process.env.E2E_BACKEND === 'true', 'mock-only regression spec');
 
   test.beforeAll(() => {
     fs.copyFileSync(path.join(fixturesDir, 'config-no-auth.json'), targetConfig);
   });
 
-  /** Route the single-vehicle NeTEx GET to a PublicationDelivery whose
-   *  `<Vehicle>` body is caller-supplied — lets each test pin the exact
-   *  Name/date elements it asserts on. */
-  const routeVehicleXml = (page: Page, body: string) =>
-    page.route('**/services/vehicles/netex/vehicles/**', async route => {
-      if (route.request().method() !== 'GET') return route.continue();
-      const id = decodeURIComponent(new URL(route.request().url()).pathname.split('/').pop() ?? '');
-      await route.fulfill({
-        status: 200,
-        contentType: 'application/xml',
-        body: vehiclePublicationDelivery(id, body),
-      });
-    });
-
-  test("Name parsed from Sobek's <Name><Text> shape shows in the title and form field", async ({
-    page,
-  }) => {
+  test('Name from the vehicles() fetch shows in the title and form field', async ({ page }) => {
     await interceptVehicleListQuery(page);
-    await routeVehicleXml(page, netexName('Oslo Tram 4'));
+    await interceptVehicleByIdQuery(page, id => vehicleRow(id, { name: { value: 'Oslo Tram 4' } }));
 
     await page.goto(SELECTED);
     await page.waitForLoadState('networkidle');
@@ -66,15 +54,16 @@ test.describe('/vehicles slider form — parsing + post-save dirty baseline (no-
     await expect(page.locator('#vehicle-name')).toHaveValue('Oslo Tram 4');
   });
 
-  test('Build and Registration dates render as native date inputs bound to the XML value', async ({
+  test('Build and Registration dates render as native date inputs bound to the fetched value', async ({
     page,
   }) => {
     await interceptVehicleListQuery(page);
-    await routeVehicleXml(
-      page,
-      netexName('Oslo Tram 4') +
-        '<BuildDate>2019-04-10</BuildDate>' +
-        '<RegistrationDate>2020-08-22</RegistrationDate>'
+    await interceptVehicleByIdQuery(page, id =>
+      vehicleRow(id, {
+        name: { value: 'Oslo Tram 4' },
+        buildDate: '2019-04-10',
+        registrationDate: '2020-08-22',
+      })
     );
 
     await page.goto(SELECTED);
@@ -92,20 +81,12 @@ test.describe('/vehicles slider form — parsing + post-save dirty baseline (no-
   test('closing the slider after a successful save does not raise the discard dialog', async ({
     page,
   }) => {
-    // Stateful list: a successful save bumps the persisted row's `version`, so
-    // the post-save list refetch returns *changed* content for VEHICLE_ID.
-    // That exercises the `rowSig` re-commit path a byte-identical mock hides.
-    const list = await interceptStatefulVehicleListQuery(page);
-    await routeVehicleXml(page, netexName('Oslo Tram 4'));
-    await page.route('**/services/vehicles/netex', async route => {
-      if (route.request().method() !== 'POST') return route.continue();
-      list.bumpVersion(VEHICLE_ID);
-      await route.fulfill({
-        status: 200,
-        contentType: 'application/xml',
-        body: vehiclePublicationDelivery(VEHICLE_ID),
-      });
-    });
+    // The save mutation resolves the vehicle id; the post-save single-vehicle
+    // refetch re-hydrates the form to the persisted value, advancing the dirty
+    // baseline so the slider is no longer considered dirty.
+    await interceptStatefulVehicleListQuery(page);
+    await interceptVehicleByIdQuery(page, id => vehicleRow(id, { name: { value: 'Oslo Tram 4' } }));
+    interceptVehicleSaveMutation(page, VEHICLE_ID);
 
     await page.goto(SELECTED);
     await page.waitForLoadState('networkidle');
@@ -114,8 +95,8 @@ test.describe('/vehicles slider form — parsing + post-save dirty baseline (no-
     await page.locator('#vehicle-name').fill('Oslo Tram 4 — renamed');
     await page.getByTestId('editor-rail-save').click();
 
-    // Save success → snackbar; the XML refetch must re-baseline the form so
-    // the slider is no longer considered dirty.
+    // Save success → snackbar; the refetch must re-baseline the form so the
+    // slider is no longer considered dirty.
     await expect(page.getByText('Vehicle saved')).toBeVisible();
 
     await page.getByTestId('editor-rail-collapse').click();

--- a/e2e-tests/no-auth/vehicle.spec.ts
+++ b/e2e-tests/no-auth/vehicle.spec.ts
@@ -2,7 +2,11 @@ import { test, expect } from '@playwright/test';
 import * as fs from 'fs';
 import * as path from 'path';
 import { fileURLToPath } from 'url';
-import { interceptVehicleListQuery } from './vehicle-list-helpers';
+import {
+  interceptVehicleListQuery,
+  interceptVehicleByIdQuery,
+  mockVehicleById,
+} from './vehicle-list-helpers';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -23,6 +27,10 @@ test.describe('/vehicles list, sidebar, deep-link, chip filter (no-auth)', () =>
   test.beforeEach(async ({ page }) => {
     if (process.env.E2E_BACKEND !== 'true') {
       await interceptVehicleListQuery(page);
+      // The slider's `useVehicle` fires `vehicles(filter:{netexIds})`; resolve
+      // it from the same fixture so a `?selected=` deep-link hydrates from the
+      // *requested* row, not the list's `content[0]`.
+      await interceptVehicleByIdQuery(page, mockVehicleById);
     }
   });
 

--- a/src/graphql/sobek.schema.graphqls
+++ b/src/graphql/sobek.schema.graphqls
@@ -14,6 +14,20 @@ input MultilingualStringInput {
 }
 
 # Enums
+enum FareClass {
+    UNKNOWN
+    FIRST_CLASS
+    SECOND_CLASS
+    THIRD_CLASS
+    PREFERENTE
+    PREMIUM_CLASS
+    BUSINESS_CLASS
+    STANDARD_CLASS
+    TURISTA
+    ECONOMY_CLASS
+    ANY
+}
+
 enum TransportMode {
     ALL
     AIR
@@ -129,6 +143,8 @@ input PrivateCodeInput {
 
 # PassengerCapacity type
 type PassengerCapacity {
+    fareClass: FareClass
+    specialPlaceCapacity: Int
     totalCapacity: Int
     seatingCapacity: Int
     standingCapacity: Int
@@ -138,6 +154,8 @@ type PassengerCapacity {
     bicycleRackCapacity: Int
 }
 input PassengerCapacityInput {
+    fareClass: FareClass
+    specialPlaceCapacity: Int
     totalCapacity: Int
     seatingCapacity: Int
     standingCapacity: Int


### PR DESCRIPTION
## The crossroad: 10 vehicle e2e reds have been latent on `main` since #101

PR #101 (`b0c1ab4`, merged 2026-06-01, shipped in v0.67.0) migrated vehicle **read + save from NeTEx XML → GraphQL** but left 4 no-auth e2e specs asserting the old XML path. Result: **10 reds on `main`**, never observed.

**Regression locus — first two commits of `feature/use-graphql-insteadof-xml-for-vehicles`:**
- `e105d34` *Replace Vehicle XML object with VehicleGQLShaped + add mutation* — `useVehicle`, `useVehiclePairSave`, `VehicleEditForm.tsx`, `fetchVehicles.ts`, new `createOrUpdateVehicle.ts`.
- `04a19cb` *Remove XML functionality* — deletes `Vehicle-parser.ts`, `fetchVehicleNetexXml.ts`, `buildVehiclePairXml.ts`, `parseVehicleImportResponse.ts`.

**The specs were never touched by #101** — last authored in #80 (`1c5ada6`), #84 (`a1e5c7e`/`dfa2062`/`39939b6`), #94 (`5753b4a`), all pre-migration. Production moved out from under stable XML tests.

| Reds | What flipped (in `e105d34` / `04a19cb`) |
|---|---|
| `vehicle-slider-form` ×3 | `useVehicle` XML→GraphQL; slider now served by the list mock (`Rail Vehicle RAIL-001`, not `Oslo Tram 4`) |
| `vehicle-create-form` ref + `vehicle-create-feedback` ×4 | save XML POST → `createOrUpdateVehicle` mutation; no XML POST → `postBody()===""`, `addCreated` never fires |
| `vehicle-create-form` Manufacturer ×1 | `VehicleEditForm.tsx` rewrite dropped the field |
| `vehicle-loading-state` ×1 | config key `applicationImportBaseUrl`→`applicationBaseUrl` + changed error string |

## Why nobody noticed: CI never ran the suite
Every Playwright run was `cancelled` at the 60-min `timeout-minutes` cap, hung on **Install Playwright Browsers**, with `Playwright auth ON`/`OFF` **skipped**. A `cancelled` run shows neutral, not a red ✗ — so the suite looked green while never executing.

**Root cause of the hang (two-step diagnosis):**
1. First guess — the apt `--with-deps` step (`8aac004`, drop `--with-deps`). **Wrong**: the next run still hung at the same step at 26 min.
2. Real cause — the **browser download** in `npx playwright install` itself stalls on the runner. Compounded by a version split: `@playwright/test@1.58.2` (what `npx playwright test` runs, with its own nested browsers) vs a top-level `playwright@1.60.0` (pulled only by `@vitest/browser-playwright`, peer `*`, not run in this CI), so `npx playwright install` even fetched the wrong browser revision.

## This PR
Run the job inside the official preinstalled image — browsers + OS deps baked in, **nothing to download**:

```yaml
container:
  image: mcr.microsoft.com/playwright:v1.58.2-noble   # matches @playwright/test 1.58.2
```

…and delete the `Install Playwright Browsers` step. This is diagnostic: it lets the suite **run**, turning the 10 latent reds into a visible red. Realigning the specs to GraphQL is a separate follow-up.

## The #101 TDD pair failed to catch this
`58745c0` (red) → `f926683` (green) land *later in #101 than the `e105d34` migration*, yet missed the regression. They only schema-validate `vehicles-list-mock.json` against the Sobek SDL at the **unit level** (the *list* query shape) — they never exercise the XML read/save/form e2e specs. So that contract went green while the e2e suite stayed red, giving false confidence that #101's fixture work was complete.

## Verify
CI on this branch should now reach and execute `Playwright auth ON`/`OFF` instead of cancelling at 1h.

# WHEN pipe fails again:

## PHASE 2
- Realign the 4 XML-era specs to the GraphQL read/save paths.
- Resolve the `@playwright/test` 1.58.2 vs `playwright` 1.60.0 split and the dual `package-lock.json` + `pnpm-lock.yaml` (CI uses `npm ci`).