### PR TITLE
Feature/add disable option

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,4 +1,4 @@
-name: Playwright Tests
+name: Tests
 on:
   push:
     branches: [ main, master ]

--- a/src/components/sidebar/EditorRail.tsx
+++ b/src/components/sidebar/EditorRail.tsx
@@ -1,5 +1,18 @@
 import { useState } from 'react';
-import { Box, CircularProgress, Divider, IconButton, Tooltip, useTheme } from '@mui/material';
+import {
+  Box,
+  CircularProgress,
+  Divider,
+  IconButton,
+  Tooltip,
+  useTheme,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogContentText,
+  DialogActions,
+  Button,
+} from '@mui/material';
 import DiscardDialog from '../dialogs/DiscardDialog.tsx';
 import {
   KeyboardDoubleArrowLeft,
@@ -27,6 +40,12 @@ interface EditorRailProps {
   onCancelEdit?: () => void;
   /** Shown in view mode as the deactivate segment. Fires the deactivation flow (which includes its own confirmation). */
   onDeactivate?: () => void;
+  /** Optional heading for the deactivate confirmation dialog. */
+  deactivateConfirmTitle?: string;
+  /** Optional body text for the deactivate confirmation dialog. */
+  deactivateConfirmMessage?: string;
+  /** Optional primary action label in the deactivate confirmation dialog. */
+  deactivateConfirmActionLabel?: string;
   /** Omit to hide the Save segment. Save is also hidden when `mode !== 'edit'`. */
   onSave?: () => void | Promise<void>;
   isDirty?: boolean;
@@ -55,6 +74,9 @@ export default function EditorRail({
   mode,
   onEnterEdit,
   onDeactivate,
+  deactivateConfirmTitle,
+  deactivateConfirmMessage,
+  deactivateConfirmActionLabel,
   onCancelEdit,
   onSave,
   isDirty = false,
@@ -65,6 +87,7 @@ export default function EditorRail({
   const theme = useTheme();
   const { t } = useTranslation();
   const [confirming, setConfirming] = useState<'collapse' | 'cancel' | null>(null);
+  const [confirmDeactivateOpen, setConfirmDeactivateOpen] = useState(false);
 
   const isEdit = mode === 'edit';
   const showPen = mode === 'view' && onEnterEdit != null;
@@ -94,6 +117,16 @@ export default function EditorRail({
   const handleSaveFromDialog = async () => {
     setConfirming(null);
     if (onSave) await onSave();
+  };
+
+  const handleDeactivateClick = () => {
+    if (!onDeactivate) return;
+    setConfirmDeactivateOpen(true);
+  };
+
+  const handleDeactivateConfirm = () => {
+    setConfirmDeactivateOpen(false);
+    onDeactivate?.();
   };
 
   const saveLabel = saving
@@ -167,7 +200,7 @@ export default function EditorRail({
               arrow
             >
               <IconButton
-                onClick={onDeactivate}
+                onClick={handleDeactivateClick}
                 aria-label={t('vehicles.rail.deactivateAria', 'Deactivate')}
                 data-testid="editor-rail-deactivate"
                 sx={{
@@ -238,6 +271,27 @@ export default function EditorRail({
         onDiscard={handleDiscard}
         onSave={onSave ? handleSaveFromDialog : undefined}
       />
+
+      <Dialog open={confirmDeactivateOpen} onClose={() => setConfirmDeactivateOpen(false)}>
+        <DialogTitle>
+          {deactivateConfirmTitle ?? t('common.deactivateConfirmTitle', 'Deactivate this item?')}
+        </DialogTitle>
+        <DialogContent>
+          <DialogContentText>
+            {deactivateConfirmMessage ??
+              t(
+                'common.deactivateConfirmMessage',
+                'This action deactivates the selected item. You can continue?'
+              )}
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setConfirmDeactivateOpen(false)}>{t('cancel', 'Cancel')}</Button>
+          <Button color="error" variant="contained" onClick={handleDeactivateConfirm}>
+            {deactivateConfirmActionLabel ?? t('common.deactivate', 'Deactivate')}
+          </Button>
+        </DialogActions>
+      </Dialog>
     </>
   );
 }

--- a/src/components/sidebar/EditorRail.tsx
+++ b/src/components/sidebar/EditorRail.tsx
@@ -281,8 +281,8 @@ export default function EditorRail({
             {deactivateConfirmMessage ??
               t(
                 'common.deactivateConfirmMessage',
-                'This action deactivates the selected item. You can continue?'
-              )}
+                'This action deactivates the selected item. Do you want to continue?'
+              )
           </DialogContentText>
         </DialogContent>
         <DialogActions>

--- a/src/components/sidebar/EditorRail.tsx
+++ b/src/components/sidebar/EditorRail.tsx
@@ -282,7 +282,7 @@ export default function EditorRail({
               t(
                 'common.deactivateConfirmMessage',
                 'This action deactivates the selected item. Do you want to continue?'
-              )
+              )}
           </DialogContentText>
         </DialogContent>
         <DialogActions>

--- a/src/components/sidebar/EditorRail.tsx
+++ b/src/components/sidebar/EditorRail.tsx
@@ -6,6 +6,7 @@ import {
   KeyboardDoubleArrowRight,
   Edit as EditIcon,
   Save as SaveIcon,
+  Block as BlockIcon,
   Cancel as CancelIcon,
 } from '@mui/icons-material';
 import { useTranslation } from 'react-i18next';
@@ -24,6 +25,8 @@ interface EditorRailProps {
   onEnterEdit?: () => void;
   /** Shown in edit mode as the cancel segment. Host should revert form + return to view mode. Rail confirms when dirty. */
   onCancelEdit?: () => void;
+  /** Shown in view mode as the deactivate segment. Fires the deactivation flow (which includes its own confirmation). */
+  onDeactivate?: () => void;
   /** Omit to hide the Save segment. Save is also hidden when `mode !== 'edit'`. */
   onSave?: () => void | Promise<void>;
   isDirty?: boolean;
@@ -51,6 +54,7 @@ export default function EditorRail({
   onCollapse,
   mode,
   onEnterEdit,
+  onDeactivate,
   onCancelEdit,
   onSave,
   isDirty = false,
@@ -64,6 +68,7 @@ export default function EditorRail({
 
   const isEdit = mode === 'edit';
   const showPen = mode === 'view' && onEnterEdit != null;
+  const showDeactivate = mode === 'view' && onDeactivate != null;
   const showCancel = isEdit && onCancelEdit != null;
   const showSave = onSave != null && isEdit;
   const collapseIcon =
@@ -148,6 +153,32 @@ export default function EditorRail({
                 }}
               >
                 <EditIcon />
+              </IconButton>
+            </Tooltip>
+          </>
+        )}
+
+        {showDeactivate && (
+          <>
+            <Divider sx={{ opacity: DIVIDER_OPACITY }} />
+            <Tooltip
+              title={t('vehicles.rail.deactivateTooltip', 'Deactivate')}
+              placement="left"
+              arrow
+            >
+              <IconButton
+                onClick={onDeactivate}
+                aria-label={t('vehicles.rail.deactivateAria', 'Deactivate')}
+                data-testid="editor-rail-deactivate"
+                sx={{
+                  width: SEGMENT_SIZE,
+                  height: SEGMENT_SIZE,
+                  borderRadius: 0,
+                  color: 'primary.main',
+                  '&:hover': { color: 'primary.dark' },
+                }}
+              >
+                <BlockIcon />
               </IconButton>
             </Tooltip>
           </>

--- a/src/data/deck-plans/api/fetchDeckPlans.ts
+++ b/src/data/deck-plans/api/fetchDeckPlans.ts
@@ -8,11 +8,13 @@ import { FETCH_ALL_SIZE } from '../../../graphql/paginationTypes.ts';
 interface DeckPlanWire {
   netexId: string;
   name?: Name | null;
+  version: number;
 }
 
 const projectDeckPlan = (dp: DeckPlanWire): DeckPlan => ({
   id: dp.netexId,
   name: dp.name ?? undefined,
+  version: dp.version,
 });
 
 export const fetchDeckPlans = async (

--- a/src/data/deck-plans/components/DeckPlanDetails.tsx
+++ b/src/data/deck-plans/components/DeckPlanDetails.tsx
@@ -15,6 +15,7 @@ import { useDeckPlanSave } from '../hooks/useDeckPlanSave.ts';
 import { DECK_PLAN_SELECTED_PARAM } from '../utils/deckPlanUrlParams.ts';
 import DeckPlanForm from './DeckPlanForm.tsx';
 import type { DeckPlan } from '../../vehicle-types/types/vehicleTypeTypes.ts';
+import { useDeckPlanDeactivate } from '../hooks/useDeckPlanDeactivate.ts';
 
 const RAIL_SIDE = 'right' as const;
 const BLANK_NAME = 'unnamed';
@@ -64,6 +65,8 @@ export default function DeckPlanDetails({
   const id = deckPlan?.id ?? null;
   const { xml, loading, error: fetchError, refetch } = useDeckPlanXml(id);
   const { save, saving, error, clearError } = useDeckPlanSave();
+  const { deactivate } = useDeckPlanDeactivate();
+  const [deactivatedOK, setDeactivatedOK] = useState(false);
 
   // Hydrate (and drop to view) whenever a fresh XML body arrives for the current row.
   useEffect(() => {
@@ -80,6 +83,28 @@ export default function DeckPlanDetails({
   useLiftEditorDirty(isDirty);
 
   const closeSlider = useCloseSliderParam(DECK_PLAN_SELECTED_PARAM);
+
+  const handleDeactivate = async () => {
+    if (!deckPlan) return;
+    const result = await deactivate(deckPlan);
+    if (result.error) {
+      setRefreshError(result.error);
+      return;
+    }
+    setMode('view');
+    try {
+      setDeactivatedOK(true);
+      await onSaved?.();
+      setRefreshError(null);
+    } catch {
+      setRefreshError(
+        t(
+          'deckPlan.deactivateStaleList',
+          'Deactivated — but the list could not refresh; it may be stale.'
+        )
+      );
+    }
+  };
 
   const handleSave = async () => {
     setRefreshError(null);
@@ -188,7 +213,8 @@ export default function DeckPlanDetails({
         side={RAIL_SIDE}
         onCollapse={closeSlider}
         mode={mode}
-        onEnterEdit={() => setMode('edit')}
+        onEnterEdit={() => !deactivatedOK && setMode('edit')}
+        onDeactivate={handleDeactivate}
         onCancelEdit={() => {
           dispatch({ type: 'hydrate', xml: state.baseline });
           setMode('view');

--- a/src/data/deck-plans/components/DeckPlanDetails.tsx
+++ b/src/data/deck-plans/components/DeckPlanDetails.tsx
@@ -75,6 +75,7 @@ export default function DeckPlanDetails({
       setMode(initialMode ?? 'view');
       setSavedAt(null);
       setRefreshError(null);
+      setDeactivatedOK(false);
     }
   }, [initialMode, deckPlan, xml]);
 
@@ -215,6 +216,12 @@ export default function DeckPlanDetails({
         mode={mode}
         onEnterEdit={() => !deactivatedOK && setMode('edit')}
         onDeactivate={handleDeactivate}
+        deactivateConfirmTitle={t('deckPlan.deactivateConfirmTitle', 'Deactivate deck plan?')}
+        deactivateConfirmMessage={t(
+          'deckPlan.deactivateConfirmMessage',
+          'This deck plan will be deactivated.'
+        )}
+        deactivateConfirmActionLabel={t('common.deactivate', 'Deactivate')}
         onCancelEdit={() => {
           dispatch({ type: 'hydrate', xml: state.baseline });
           setMode('view');

--- a/src/data/deck-plans/hooks/useDeckPlanDeactivate.ts
+++ b/src/data/deck-plans/hooks/useDeckPlanDeactivate.ts
@@ -1,0 +1,66 @@
+import { useCallback, useState } from 'react';
+import { useAuth } from '../../../auth/authUtils.ts';
+import { useConfig } from '../../../contexts/configContext.ts';
+import { useOrganisations } from '../../organisations/hooks/useOrganisations.ts';
+import { deactivateDeckPlanRequest } from '../../../graphql/vehicles/mutations/deactivateDeckPlan.ts';
+import type { DeckPlan } from '../../vehicle-types/types/vehicleTypeTypes.ts';
+
+interface SaveResult {
+  newVersion: number | null;
+  error: string | null;
+}
+
+interface UseDeckPlanDeactivateResult {
+  deactivate: (form: DeckPlan) => Promise<SaveResult>;
+  saving: boolean;
+  error: string | null;
+  clearError: () => void;
+}
+
+/**
+ * Deactivate a DeckPlan via the `deactivateDeckPlan` GraphQL mutation.
+ *
+ * @returns `deactivate` (→ `{ newVersion, error }`), plus `saving`, `error`, `clearError`.
+ */
+export function useDeckPlanDeactivate(): UseDeckPlanDeactivateResult {
+  const { getAccessToken } = useAuth();
+  const { applicationBaseUrl } = useConfig();
+  const { currentOrganisation } = useOrganisations();
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const deactivate = useCallback(
+    async (form: DeckPlan): Promise<SaveResult> => {
+      if (!applicationBaseUrl) {
+        const message = 'Application base URL is not configured';
+        setError(message);
+        return { newVersion: null, error: message };
+      }
+      if (!currentOrganisation?.id) {
+        const message = 'No organisation selected — cannot deactivate deck plan';
+        setError(message);
+        return { newVersion: null, error: message };
+      }
+      setSaving(true);
+      setError(null);
+      try {
+        const token = await getAccessToken();
+        const body = await deactivateDeckPlanRequest(applicationBaseUrl, token, {
+          netexId: form.id,
+          version: Number(form.version),
+          deactivateAt: new Date().toISOString(),
+        });
+        return { newVersion: body.deactivateDeckPlan?.version ?? null, error: null };
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        setError(message);
+        return { newVersion: null, error: message };
+      } finally {
+        setSaving(false);
+      }
+    },
+    [applicationBaseUrl, getAccessToken, currentOrganisation?.id]
+  );
+
+  return { deactivate, saving, error, clearError: () => setError(null) };
+}

--- a/src/data/vehicle-types/api/fetchVehicleTypes.ts
+++ b/src/data/vehicle-types/api/fetchVehicleTypes.ts
@@ -39,7 +39,7 @@ export interface VehicleTypeWire {
   created?: string | null;
   changed?: string | null;
   changedBy?: string | null;
-  deckPlan?: { netexId: string; name?: Name | null } | null;
+  deckPlan?: { netexId: string; name?: Name | null; version: number } | null;
   vehicles?:
     | {
         netexId: string;
@@ -84,7 +84,7 @@ export const projectVehicleType = (vt: VehicleTypeWire): VehicleType => ({
   changed: vt.changed ?? undefined,
   changedBy: vt.changedBy ?? undefined,
   deckPlan: vt.deckPlan
-    ? { id: vt.deckPlan.netexId, name: vt.deckPlan.name ?? undefined }
+    ? { id: vt.deckPlan.netexId, name: vt.deckPlan.name ?? undefined, version: vt.deckPlan.version }
     : undefined,
   vehicles: vt.vehicles
     ? vt.vehicles.map(v => ({
@@ -121,7 +121,7 @@ export interface VehicleTypeInput {
   fuelTypes?: (FuelType | null)[] | null;
   transportMode?: string | null;
   passengerCapacity?: PassengerCapacity | null;
-  deckPlan?: { netexId: string } | null;
+  deckPlan?: { netexId: string; version: number | null } | null;
   formDragCoefficient?: number | null;
   rollResistanceCoefficient?: number | null;
   maximumEngineEffectKW?: number | null;
@@ -171,7 +171,7 @@ export const serializeVehicleType = (vt: VehicleType, dataOwnerRef: string): Veh
   fuelTypes: vt.fuelTypes ?? null,
   transportMode: vt.transportMode ?? null,
   passengerCapacity: vt.passengerCapacity ?? null,
-  deckPlan: vt.deckPlan ? { netexId: vt.deckPlan.id } : null,
+  deckPlan: vt.deckPlan ? { netexId: vt.deckPlan.id, version: vt.deckPlan.version ?? null } : null,
   formDragCoefficient: vt.formDragCoefficient ?? null,
   rollResistanceCoefficient: vt.rollResistanceCoefficient ?? null,
   maximumEngineEffectKW: vt.maximumEngineEffectKW ?? null,

--- a/src/data/vehicle-types/api/fetchVehicleTypes.ts
+++ b/src/data/vehicle-types/api/fetchVehicleTypes.ts
@@ -96,6 +96,12 @@ export const projectVehicleType = (vt: VehicleTypeWire): VehicleType => ({
     : undefined,
 });
 
+export interface DeactivateInput {
+  netexId: string;
+  version: number;
+  deactivateAt: string;
+}
+
 /**
  * Sobek `VehicleTypeInput` — the mutation-accepted shape. Strict subset of the
  * fetched {@link VehicleTypeWire}: no `version`/`created`/`changed`/`changedBy`

--- a/src/data/vehicle-types/api/fetchVehicleTypes.ts
+++ b/src/data/vehicle-types/api/fetchVehicleTypes.ts
@@ -121,7 +121,7 @@ export interface VehicleTypeInput {
   fuelTypes?: (FuelType | null)[] | null;
   transportMode?: string | null;
   passengerCapacity?: PassengerCapacity | null;
-  deckPlan?: { netexId: string; version: number | null } | null;
+  deckPlan?: { netexId: string } | null;
   formDragCoefficient?: number | null;
   rollResistanceCoefficient?: number | null;
   maximumEngineEffectKW?: number | null;
@@ -171,7 +171,7 @@ export const serializeVehicleType = (vt: VehicleType, dataOwnerRef: string): Veh
   fuelTypes: vt.fuelTypes ?? null,
   transportMode: vt.transportMode ?? null,
   passengerCapacity: vt.passengerCapacity ?? null,
-  deckPlan: vt.deckPlan ? { netexId: vt.deckPlan.id, version: vt.deckPlan.version ?? null } : null,
+  deckPlan: vt.deckPlan ? { netexId: vt.deckPlan.id } : null,
   formDragCoefficient: vt.formDragCoefficient ?? null,
   rollResistanceCoefficient: vt.rollResistanceCoefficient ?? null,
   maximumEngineEffectKW: vt.maximumEngineEffectKW ?? null,

--- a/src/data/vehicle-types/components/VehicleTypeDetails.tsx
+++ b/src/data/vehicle-types/components/VehicleTypeDetails.tsx
@@ -257,7 +257,7 @@ export default function VehicleTypeDetails({
       />
       <SaveSuccessSnackbar
         open={deactivatedOK}
-        message={t('vehicleTypes.deactivateSuccess', 'Vehicle type deactivated')}
+        message={t('vehicleType.deactivateSuccess', 'Vehicle type deactivated')}
         onClose={closeSlider}
       />
       <EditorRail

--- a/src/data/vehicle-types/components/VehicleTypeDetails.tsx
+++ b/src/data/vehicle-types/components/VehicleTypeDetails.tsx
@@ -79,6 +79,7 @@ export default function VehicleTypeDetails({
   const [state, dispatch] = useReducer(formReducer, { form: EMPTY_VTYPE, baseline: EMPTY_VTYPE });
   const { save, saving, error, clearError } = useVehicleTypeSave();
   const { deactivate } = useVehicleTypeDeactivate();
+  const [deactivatedOK, setDeactivatedOK] = useState(false);
 
   // Re-hydrate (and drop back to view) whenever the deep-link resolves a new row.
   useEffect(() => {
@@ -109,6 +110,7 @@ export default function VehicleTypeDetails({
     }
     setMode('view');
     try {
+      setDeactivatedOK(true);
       await onSaved?.();
       setRefreshError(null);
     } catch {
@@ -252,10 +254,15 @@ export default function VehicleTypeDetails({
         message={t('vehicleType.saveSuccess', 'Vehicle type saved')}
         onClose={() => setSavedAt(null)}
       />
+      <SaveSuccessSnackbar
+        open={deactivatedOK}
+        message={t('vehicleTypes.deactivateSuccess', 'Vehicle type deactivated')}
+        onClose={closeSlider}
+      />
       <EditorRail
         side={RAIL_SIDE}
         onCollapse={closeSlider}
-        mode={mode}
+        mode={deactivatedOK ? 'view' : mode}
         onEnterEdit={() => setMode('edit')}
         onDeactivate={handleDeactivate}
         onCancelEdit={() => {

--- a/src/data/vehicle-types/components/VehicleTypeDetails.tsx
+++ b/src/data/vehicle-types/components/VehicleTypeDetails.tsx
@@ -262,8 +262,8 @@ export default function VehicleTypeDetails({
       <EditorRail
         side={RAIL_SIDE}
         onCollapse={closeSlider}
-        mode={deactivatedOK ? 'view' : mode}
-        onEnterEdit={() => setMode('edit')}
+        mode={mode}
+        onEnterEdit={() => !deactivatedOK && setMode('edit')}
         onDeactivate={handleDeactivate}
         onCancelEdit={() => {
           // Revert to the last committed baseline (post-save = saved values),

--- a/src/data/vehicle-types/components/VehicleTypeDetails.tsx
+++ b/src/data/vehicle-types/components/VehicleTypeDetails.tsx
@@ -15,6 +15,7 @@ import { useVehicleTypeSave } from '../hooks/useVehicleTypeSave.ts';
 import { VEHICLE_TYPE_SELECTED_PARAM } from '../utils/vehicleTypeUrlParams.ts';
 import VehicleTypeForm from './VehicleTypeForm.tsx';
 import type { VehicleType } from '../types/vehicleTypeTypes.ts';
+import { useVehicleTypeDeactivate } from '../hooks/useVehicleTypeDeactivate.ts';
 
 const BLANK_NAME = 'unnamed';
 const RAIL_SIDE = 'right' as const;
@@ -77,6 +78,7 @@ export default function VehicleTypeDetails({
   const [refreshError, setRefreshError] = useState<string | null>(null);
   const [state, dispatch] = useReducer(formReducer, { form: EMPTY_VTYPE, baseline: EMPTY_VTYPE });
   const { save, saving, error, clearError } = useVehicleTypeSave();
+  const { deactivate } = useVehicleTypeDeactivate();
 
   // Re-hydrate (and drop back to view) whenever the deep-link resolves a new row.
   useEffect(() => {
@@ -98,6 +100,26 @@ export default function VehicleTypeDetails({
 
   const closeSlider = useCloseSliderParam(VEHICLE_TYPE_SELECTED_PARAM);
   const advanceCreated = useSidebarCreateAdvance(VEHICLE_TYPE_SELECTED_PARAM);
+
+  const handleDeactivate = async () => {
+    const result = await deactivate(state.form);
+    if (result.error) {
+      setRefreshError(result.error);
+      return;
+    }
+    setMode('view');
+    try {
+      await onSaved?.();
+      setRefreshError(null);
+    } catch {
+      setRefreshError(
+        t(
+          'vehicleType.deactivateStaleList',
+          'Deactivated — but the list could not refresh; it may be stale.'
+        )
+      );
+    }
+  };
 
   // Fire the mutation, then refresh the list (`onSaved`) so the table reflects
   // the edit. The sidebar's own re-baseline is from the submitted form, not the
@@ -235,6 +257,7 @@ export default function VehicleTypeDetails({
         onCollapse={closeSlider}
         mode={mode}
         onEnterEdit={() => setMode('edit')}
+        onDeactivate={handleDeactivate}
         onCancelEdit={() => {
           // Revert to the last committed baseline (post-save = saved values),
           // not the `vehicleType` prop which goes stale after a same-id save.

--- a/src/data/vehicle-types/components/VehicleTypeDetails.tsx
+++ b/src/data/vehicle-types/components/VehicleTypeDetails.tsx
@@ -89,6 +89,7 @@ export default function VehicleTypeDetails({
       // Don't let a prior save snackbar / stale-list warning bleed into the next row.
       setSavedAt(null);
       setRefreshError(null);
+      setDeactivatedOK(false);
     }
   }, [initialMode, vehicleType]);
 
@@ -265,6 +266,12 @@ export default function VehicleTypeDetails({
         mode={mode}
         onEnterEdit={() => !deactivatedOK && setMode('edit')}
         onDeactivate={handleDeactivate}
+        deactivateConfirmTitle={t('vehicleType.deactivateConfirmTitle', 'Deactivate vehicle type?')}
+        deactivateConfirmMessage={t(
+          'vehicleType.deactivateConfirmMessage',
+          'This vehicle type will be deactivated.'
+        )}
+        deactivateConfirmActionLabel={t('common.deactivate', 'Deactivate')}
         onCancelEdit={() => {
           // Revert to the last committed baseline (post-save = saved values),
           // not the `vehicleType` prop which goes stale after a same-id save.

--- a/src/data/vehicle-types/hooks/useVehicleTypeDeactivate.ts
+++ b/src/data/vehicle-types/hooks/useVehicleTypeDeactivate.ts
@@ -1,0 +1,66 @@
+import { useCallback, useState } from 'react';
+import { useAuth } from '../../../auth/authUtils.ts';
+import { useConfig } from '../../../contexts/configContext.ts';
+import type { VehicleType } from '../types/vehicleTypeTypes.ts';
+import { useOrganisations } from '../../organisations/hooks/useOrganisations.ts';
+import { deactivateVehicleTypeRequest } from '../../../graphql/vehicles/mutations/deactivateVehicleType.ts';
+
+interface SaveResult {
+  newVersion: number | null;
+  error: string | null;
+}
+
+interface UseVehicleTypeDeactivateResult {
+  deactivate: (form: VehicleType) => Promise<SaveResult>;
+  saving: boolean;
+  error: string | null;
+  clearError: () => void;
+}
+
+/**
+ * Deactivate a VehicleType via the `deactivateVehicleType` GraphQL mutation.
+ *
+ * @returns `deactivate` (→ `{ newVersion, error }`), plus `saving`, `error`, `clearError`.
+ */
+export function useVehicleTypeDeactivate(): UseVehicleTypeDeactivateResult {
+  const { getAccessToken } = useAuth();
+  const { applicationBaseUrl } = useConfig();
+  const { currentOrganisation } = useOrganisations();
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const deactivate = useCallback(
+    async (form: VehicleType): Promise<SaveResult> => {
+      if (!applicationBaseUrl) {
+        const message = 'Application base URL is not configured';
+        setError(message);
+        return { newVersion: null, error: message };
+      }
+      if (!currentOrganisation?.id) {
+        const message = 'No organisation selected — cannot deactivate vehicle type';
+        setError(message);
+        return { newVersion: null, error: message };
+      }
+      setSaving(true);
+      setError(null);
+      try {
+        const token = await getAccessToken();
+        const body = await deactivateVehicleTypeRequest(applicationBaseUrl, token, {
+          netexId: form.id,
+          version: Number(form.version),
+          deactivateAt: new Date().toISOString(),
+        });
+        return { newVersion: body.deactivateVehicleType?.version ?? null, error: null };
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        setError(message);
+        return { newVersion: null, error: message };
+      } finally {
+        setSaving(false);
+      }
+    },
+    [applicationBaseUrl, getAccessToken, currentOrganisation?.id]
+  );
+
+  return { deactivate, saving, error, clearError: () => setError(null) };
+}

--- a/src/data/vehicle-types/types/vehicleTypeTypes.ts
+++ b/src/data/vehicle-types/types/vehicleTypeTypes.ts
@@ -7,6 +7,7 @@ export type Name = {
 
 export type DeckPlan = {
   id: string;
+  version?: number;
   name?: Name;
 };
 

--- a/src/data/vehicles/components/VehicleDetails.tsx
+++ b/src/data/vehicles/components/VehicleDetails.tsx
@@ -71,6 +71,7 @@ export default function VehicleDetails({
 
   useEffect(() => {
     dispatch({ type: 'hydrate', xmlVehicle });
+    setDeactivatedOK(false);
   }, [xmlVehicle]);
 
   const isDirty = isFormDirty(formState);
@@ -257,6 +258,12 @@ export default function VehicleDetails({
         mode={mode}
         onEnterEdit={() => !deactivatedOK && setMode('edit')}
         onDeactivate={handleDeactivate}
+        deactivateConfirmTitle={t('vehicle.deactivateConfirmTitle', 'Deactivate vehicle?')}
+        deactivateConfirmMessage={t(
+          'vehicle.deactivateConfirmMessage',
+          'This vehicle will be deactivated.'
+        )}
+        deactivateConfirmActionLabel={t('common.deactivate', 'Deactivate')}
         onCancelEdit={() => {
           dispatch({ type: 'hydrate', xmlVehicle });
           setMode('view');

--- a/src/data/vehicles/components/VehicleDetails.tsx
+++ b/src/data/vehicles/components/VehicleDetails.tsx
@@ -28,6 +28,7 @@ import {
   type FormState,
 } from '../stores/vehicleFormState.ts';
 import type { VehicleEditFormValue } from './VehicleEditForm.tsx';
+import { useVehicleDeactivate } from '../hooks/useVehicleDeactivate.ts';
 
 const BLANK_NAME = 'unnamed';
 const RAIL_SIDE = 'right' as const;
@@ -58,6 +59,8 @@ export default function VehicleDetails({
   const [savedAt, setSavedAt] = useState<number | null>(null);
   const [commitError, setCommitError] = useState<string | null>(null);
   const { save, saving, error, clearError } = useVehiclePairSave();
+  const { deactivate } = useVehicleDeactivate();
+  const [deactivatedOK, setDeactivatedOK] = useState(false);
 
   const {
     data: xmlVehicle,
@@ -76,6 +79,27 @@ export default function VehicleDetails({
 
   const closeSlider = useCloseSliderParam(VEHICLE_SELECTED_PARAM);
   const advanceCreated = useSidebarCreateAdvance(VEHICLE_SELECTED_PARAM);
+
+  const handleDeactivate = async () => {
+    const result = await deactivate(form.vehicle);
+    if (result.error) {
+      setCommitError(result.error);
+      return;
+    }
+    setMode('view');
+    try {
+      setDeactivatedOK(true);
+      await onSaved?.();
+      setCommitError(null);
+    } catch {
+      setCommitError(
+        t(
+          'vehicle.deactivateStaleList',
+          'Deactivated — but the list could not refresh; it may be stale.'
+        )
+      );
+    }
+  };
 
   const handleSave = async () => {
     const wasCreate = (form.vehicle.id ?? '') === '';
@@ -222,11 +246,17 @@ export default function VehicleDetails({
         message={t('vehicles.saveSuccess', 'Vehicle saved')}
         onClose={() => setSavedAt(null)}
       />
+      <SaveSuccessSnackbar
+        open={deactivatedOK}
+        message={t('vehicles.deactivateSuccess', 'Vehicle deactivated')}
+        onClose={closeSlider}
+      />
       <EditorRail
         side={RAIL_SIDE}
         onCollapse={closeSlider}
-        mode={mode}
+        mode={deactivatedOK ? 'view' : mode}
         onEnterEdit={() => setMode('edit')}
+        onDeactivate={handleDeactivate}
         onCancelEdit={() => {
           dispatch({ type: 'hydrate', xmlVehicle });
           setMode('view');

--- a/src/data/vehicles/components/VehicleDetails.tsx
+++ b/src/data/vehicles/components/VehicleDetails.tsx
@@ -254,8 +254,8 @@ export default function VehicleDetails({
       <EditorRail
         side={RAIL_SIDE}
         onCollapse={closeSlider}
-        mode={deactivatedOK ? 'view' : mode}
-        onEnterEdit={() => setMode('edit')}
+        mode={mode}
+        onEnterEdit={() => !deactivatedOK && setMode('edit')}
         onDeactivate={handleDeactivate}
         onCancelEdit={() => {
           dispatch({ type: 'hydrate', xmlVehicle });

--- a/src/data/vehicles/hooks/useVehicleDeactivate.ts
+++ b/src/data/vehicles/hooks/useVehicleDeactivate.ts
@@ -1,0 +1,66 @@
+import { useCallback, useState } from 'react';
+import { useAuth } from '../../../auth/authUtils.ts';
+import { useConfig } from '../../../contexts/configContext.ts';
+import { useOrganisations } from '../../organisations/hooks/useOrganisations.ts';
+import { deactivateVehicleRequest } from '../../../graphql/vehicles/mutations/deactivateVehicle.ts';
+import type { VehicleGQLShaped } from '../types/vehicleGqlShaped.ts';
+
+interface SaveResult {
+  newVersion: number | null;
+  error: string | null;
+}
+
+interface UseVehicleDeactivateResult {
+  deactivate: (form: VehicleGQLShaped) => Promise<SaveResult>;
+  saving: boolean;
+  error: string | null;
+  clearError: () => void;
+}
+
+/**
+ * Deactivate a Vehicle via the `deactivateVehicle` GraphQL mutation.
+ *
+ * @returns `deactivate` (→ `{ newVersion, error }`), plus `saving`, `error`, `clearError`.
+ */
+export function useVehicleDeactivate(): UseVehicleDeactivateResult {
+  const { getAccessToken } = useAuth();
+  const { applicationBaseUrl } = useConfig();
+  const { currentOrganisation } = useOrganisations();
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const deactivate = useCallback(
+    async (form: VehicleGQLShaped): Promise<SaveResult> => {
+      if (!applicationBaseUrl) {
+        const message = 'Application base URL is not configured';
+        setError(message);
+        return { newVersion: null, error: message };
+      }
+      if (!currentOrganisation?.id) {
+        const message = 'No organisation selected — cannot deactivate vehicle';
+        setError(message);
+        return { newVersion: null, error: message };
+      }
+      setSaving(true);
+      setError(null);
+      try {
+        const token = await getAccessToken();
+        const body = await deactivateVehicleRequest(applicationBaseUrl, token, {
+          netexId: form.id,
+          version: Number(form.version),
+          deactivateAt: new Date().toISOString(),
+        });
+        return { newVersion: body.deactivateVehicle?.version ?? null, error: null };
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        setError(message);
+        return { newVersion: null, error: message };
+      } finally {
+        setSaving(false);
+      }
+    },
+    [applicationBaseUrl, getAccessToken, currentOrganisation?.id]
+  );
+
+  return { deactivate, saving, error, clearError: () => setError(null) };
+}

--- a/src/graphql/vehicles/mutations/deactivateDeckPlan.ts
+++ b/src/graphql/vehicles/mutations/deactivateDeckPlan.ts
@@ -11,7 +11,7 @@ const deactivateDeckPlanMutation = gql`
   }
 `;
 
-/** Mutation response: the persisted Vehicle's NeTEx id (nullable per SDL). */
+/** Mutation response: the persisted DeckPlan's NeTEx id + version (nullable per SDL). */
 export interface DeactivateDeckPlanResponse {
   deactivateDeckPlan: {
     netexId: string;
@@ -22,11 +22,11 @@ export interface DeactivateDeckPlanResponse {
 export const deactivateDeckPlanRequest = (
   applicationBaseUrl: string,
   token: AccessToken,
-  vehicleData: DeactivateInput
+  deckPlanData: DeactivateInput
 ): Promise<DeactivateDeckPlanResponse> =>
   request<DeactivateDeckPlanResponse>(
     applicationBaseUrl,
     deactivateDeckPlanMutation,
-    { input: vehicleData },
+    { input: deckPlanData },
     authHeader(token)
   );

--- a/src/graphql/vehicles/mutations/deactivateDeckPlan.ts
+++ b/src/graphql/vehicles/mutations/deactivateDeckPlan.ts
@@ -1,0 +1,32 @@
+import { request, gql } from 'graphql-request';
+import { authHeader, type AccessToken } from '../../../auth/index.ts';
+import type { DeactivateInput } from '../../../data/vehicle-types/api/fetchVehicleTypes.ts';
+
+const deactivateDeckPlanMutation = gql`
+  mutation DeactivateDeckPlan($input: DeactivateInput!) {
+    deactivateDeckPlan(input: $input) {
+      netexId
+      version
+    }
+  }
+`;
+
+/** Mutation response: the persisted Vehicle's NeTEx id (nullable per SDL). */
+export interface DeactivateDeckPlanResponse {
+  deactivateDeckPlan: {
+    netexId: string;
+    version: number;
+  } | null;
+}
+
+export const deactivateDeckPlanRequest = (
+  applicationBaseUrl: string,
+  token: AccessToken,
+  vehicleData: DeactivateInput
+): Promise<DeactivateDeckPlanResponse> =>
+  request<DeactivateDeckPlanResponse>(
+    applicationBaseUrl,
+    deactivateDeckPlanMutation,
+    { input: vehicleData },
+    authHeader(token)
+  );

--- a/src/graphql/vehicles/mutations/deactivateVehicle.ts
+++ b/src/graphql/vehicles/mutations/deactivateVehicle.ts
@@ -12,6 +12,7 @@ const deactivateVehicleMutation = gql`
 `;
 
 /** Mutation response: the persisted Vehicle's NeTEx id + version (nullable per SDL). */
+export interface DeactivateVehicleResponse {
   deactivateVehicle: {
     netexId: string;
     version: number;

--- a/src/graphql/vehicles/mutations/deactivateVehicle.ts
+++ b/src/graphql/vehicles/mutations/deactivateVehicle.ts
@@ -11,8 +11,7 @@ const deactivateVehicleMutation = gql`
   }
 `;
 
-/** Mutation response: the persisted Vehicle's NeTEx id (nullable per SDL). */
-export interface DeactivateVehicleResponse {
+/** Mutation response: the persisted Vehicle's NeTEx id + version (nullable per SDL). */
   deactivateVehicle: {
     netexId: string;
     version: number;

--- a/src/graphql/vehicles/mutations/deactivateVehicle.ts
+++ b/src/graphql/vehicles/mutations/deactivateVehicle.ts
@@ -1,0 +1,32 @@
+import { request, gql } from 'graphql-request';
+import { authHeader, type AccessToken } from '../../../auth/index.ts';
+import type { DeactivateInput } from '../../../data/vehicle-types/api/fetchVehicleTypes.ts';
+
+const deactivateVehicleMutation = gql`
+  mutation DeactivateVehicle($input: DeactivateInput!) {
+    deactivateVehicle(input: $input) {
+      netexId
+      version
+    }
+  }
+`;
+
+/** Mutation response: the persisted Vehicle's NeTEx id (nullable per SDL). */
+export interface DeactivateVehicleResponse {
+  deactivateVehicle: {
+    netexId: string;
+    version: number;
+  } | null;
+}
+
+export const deactivateVehicleRequest = (
+  applicationBaseUrl: string,
+  token: AccessToken,
+  vehicleData: DeactivateInput
+): Promise<DeactivateVehicleResponse> =>
+  request<DeactivateVehicleResponse>(
+    applicationBaseUrl,
+    deactivateVehicleMutation,
+    { input: vehicleData },
+    authHeader(token)
+  );

--- a/src/graphql/vehicles/mutations/deactivateVehicleType.ts
+++ b/src/graphql/vehicles/mutations/deactivateVehicleType.ts
@@ -11,8 +11,7 @@ const deactivateVehicleTypeMutation = gql`
   }
 `;
 
-/** Mutation response: the persisted VehicleType's NeTEx id (nullable per SDL). */
-export interface DeactivateVehicleTypeResponse {
+/** Mutation response: the persisted VehicleType's NeTEx id + version (nullable per SDL). */
   deactivateVehicleType: {
     netexId: string;
     version: number;

--- a/src/graphql/vehicles/mutations/deactivateVehicleType.ts
+++ b/src/graphql/vehicles/mutations/deactivateVehicleType.ts
@@ -12,6 +12,7 @@ const deactivateVehicleTypeMutation = gql`
 `;
 
 /** Mutation response: the persisted VehicleType's NeTEx id + version (nullable per SDL). */
+export interface DeactivateVehicleTypeResponse {
   deactivateVehicleType: {
     netexId: string;
     version: number;

--- a/src/graphql/vehicles/mutations/deactivateVehicleType.ts
+++ b/src/graphql/vehicles/mutations/deactivateVehicleType.ts
@@ -1,0 +1,32 @@
+import { request, gql } from 'graphql-request';
+import { authHeader, type AccessToken } from '../../../auth/index.ts';
+import type { DeactivateInput } from '../../../data/vehicle-types/api/fetchVehicleTypes.ts';
+
+const deactivateVehicleTypeMutation = gql`
+  mutation DeactivateVehicleType($input: DeactivateInput!) {
+    deactivateVehicleType(input: $input) {
+      netexId
+      version
+    }
+  }
+`;
+
+/** Mutation response: the persisted VehicleType's NeTEx id (nullable per SDL). */
+export interface DeactivateVehicleTypeResponse {
+  deactivateVehicleType: {
+    netexId: string;
+    version: number;
+  } | null;
+}
+
+export const deactivateVehicleTypeRequest = (
+  applicationBaseUrl: string,
+  token: AccessToken,
+  vehicleTypeData: DeactivateInput
+): Promise<DeactivateVehicleTypeResponse> =>
+  request<DeactivateVehicleTypeResponse>(
+    applicationBaseUrl,
+    deactivateVehicleTypeMutation,
+    { input: vehicleTypeData },
+    authHeader(token)
+  );

--- a/src/graphql/vehicles/queries/fetchDeckPlans.ts
+++ b/src/graphql/vehicles/queries/fetchDeckPlans.ts
@@ -9,6 +9,7 @@ const fetchDeckPlansGQL = gql`
         name {
           value
         }
+        version
       }
       totalElements
       page

--- a/src/graphql/vehicles/queries/fetchVehicleTypes.ts
+++ b/src/graphql/vehicles/queries/fetchVehicleTypes.ts
@@ -46,6 +46,7 @@ const fetchVehicleTypesGQL = gql`
         changedBy
         deckPlan {
           netexId
+          version
           name {
             value
           }

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -116,7 +116,7 @@
   "vehicleType.saveSuccess": "Vehicle type saved",
   "vehicleType.saveStaleList": "Saved — but the list could not refresh; it may be stale.",
   "vehicleType.deactivateStaleList": "Deactivated — but the list could not refresh; it may be stale.",
-  "vehicleTypes.deactivateSuccess": "Vehicle type deactivated",
+  "vehicleType.deactivateSuccess": "Vehicle type deactivated",
   "vehicleType.deactivateConfirmTitle": "Deactivate vehicle type?",
   "vehicleType.deactivateConfirmMessage": "This vehicle type will be deactivated.",
   "vehicleType.tab.edit": "Edit",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -216,6 +216,6 @@
   "deckPlan.deactivateConfirmTitle": "Deactivate deck plan?",
   "deckPlan.deactivateConfirmMessage": "This deck plan will be deactivated.",
   "common.deactivateConfirmTitle": "Deactivate this item?",
-  "common.deactivateConfirmMessage": "This action deactivates the selected item. You can continue?",
+  "common.deactivateConfirmMessage": "This action deactivates the selected item. Do you want to continue?",
   "common.deactivate": "Deactivate"
 }

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -59,6 +59,7 @@
   "deckPlans.notFound": "Deck plan not found",
   "deckPlans.saveSuccess": "Deck plan saved",
   "deckPlans.saveStaleList": "Saved — but the list could not refresh; it may be stale.",
+  "deckPlan.deactivateStaleList": "Deactivated — but the list could not refresh; it may be stale.",
   "deckPlans.newComingSoon": "Coming soon",
   "deckPlans.actions.new": "New Deck Plan",
   "breadcrumbs.home": "Home",
@@ -114,6 +115,10 @@
   "vehicleType.notFound": "Vehicle type not found",
   "vehicleType.saveSuccess": "Vehicle type saved",
   "vehicleType.saveStaleList": "Saved — but the list could not refresh; it may be stale.",
+  "vehicleType.deactivateStaleList": "Deactivated — but the list could not refresh; it may be stale.",
+  "vehicleTypes.deactivateSuccess": "Vehicle type deactivated",
+  "vehicleType.deactivateConfirmTitle": "Deactivate vehicle type?",
+  "vehicleType.deactivateConfirmMessage": "This vehicle type will be deactivated.",
   "vehicleType.tab.edit": "Edit",
   "vehicleType.tab.propulsion": "Propulsion/perf.",
   "vehicleType.tab.capacity": "Passenger Capacity",
@@ -155,6 +160,10 @@
   "vehicles.notFound": "Vehicle not found",
   "vehicles.loading": "Loading vehicle…",
   "vehicles.saveSuccess": "Vehicle saved",
+  "vehicle.deactivateStaleList": "Deactivated — but the list could not refresh; it may be stale.",
+  "vehicles.deactivateSuccess": "Vehicle deactivated",
+  "vehicle.deactivateConfirmTitle": "Deactivate vehicle?",
+  "vehicle.deactivateConfirmMessage": "This vehicle will be deactivated.",
   "vehicles.saveSuccess.viewInList": "View in list",
   "vehicles.actions.back": "Back to list",
   "vehicles.field.transportType": "Vehicle Type ID",
@@ -194,6 +203,8 @@
   "rail.label": "Main navigation",
   "rail.collapse": "Collapse menu",
   "rail.expand": "Expand menu",
+  "vehicles.rail.deactivateTooltip": "Deactivate",
+  "vehicles.rail.deactivateAria": "Deactivate",
 
   "product": "Product",
   "product.electronics": "Electronics",
@@ -201,5 +212,10 @@
   "product.clothing": "Clothing",
 
   "organisations.select.label": "Select organisation",
-  "organisations.select.noOptions": "No organisations available"
+  "organisations.select.noOptions": "No organisations available",
+  "deckPlan.deactivateConfirmTitle": "Deactivate deck plan?",
+  "deckPlan.deactivateConfirmMessage": "This deck plan will be deactivated.",
+  "common.deactivateConfirmTitle": "Deactivate this item?",
+  "common.deactivateConfirmMessage": "This action deactivates the selected item. You can continue?",
+  "common.deactivate": "Deactivate"
 }

--- a/src/locales/nb/translation.json
+++ b/src/locales/nb/translation.json
@@ -59,6 +59,7 @@
   "deckPlans.notFound": "Fant ikke setekartet",
   "deckPlans.saveSuccess": "Setekart lagret",
   "deckPlans.saveStaleList": "Lagret — men listen kunne ikke oppdateres; den kan være utdatert.",
+  "deckPlan.deactivateStaleList": "Deaktivert — men listen kunne ikke oppdateres; den kan være utdatert.",
   "deckPlans.newComingSoon": "Kommer snart",
   "deckPlans.actions.new": "Nytt setekart",
   "breadcrumbs.home": "Hjem",
@@ -114,6 +115,10 @@
   "vehicleType.notFound": "Kjøretøytype ikke funnet",
   "vehicleType.saveSuccess": "Kjøretøytype lagret",
   "vehicleType.saveStaleList": "Lagret — men listen kunne ikke oppdateres; den kan være utdatert.",
+  "vehicleType.deactivateStaleList": "Deaktivert — men listen kunne ikke oppdateres; den kan være utdatert.",
+  "vehicleTypes.deactivateSuccess": "Kjøretøytype deaktivert",
+  "vehicleType.deactivateConfirmTitle": "Deaktivere kjøretøytype?",
+  "vehicleType.deactivateConfirmMessage": "Denne kjøretøytypen vil bli deaktivert.",
   "vehicleType.tab.edit": "Rediger",
   "vehicleType.tab.propulsion": "Fremdrift/yt.",
   "vehicleType.tab.capacity": "Passasjerkapasitet",
@@ -155,6 +160,10 @@
   "vehicles.notFound": "Kjøretøy ikke funnet",
   "vehicles.loading": "Laster kjøretøy…",
   "vehicles.saveSuccess": "Kjøretøy lagret",
+  "vehicle.deactivateStaleList": "Deaktivert — men listen kunne ikke oppdateres; den kan være utdatert.",
+  "vehicles.deactivateSuccess": "Kjøretøy deaktivert",
+  "vehicle.deactivateConfirmTitle": "Deaktivere kjøretøy?",
+  "vehicle.deactivateConfirmMessage": "Dette kjøretøyet vil bli deaktivert.",
   "vehicles.saveSuccess.viewInList": "Vis i liste",
   "vehicles.actions.back": "Tilbake til liste",
   "vehicles.field.transportType": "Kjøretøytype-ID",
@@ -194,6 +203,8 @@
   "rail.label": "Hovedmeny",
   "rail.collapse": "Skjul meny",
   "rail.expand": "Vis meny",
+  "vehicles.rail.deactivateTooltip": "Deaktiver",
+  "vehicles.rail.deactivateAria": "Deaktiver",
 
   "import.result.fuelTypeEnum.battery": "Elektrisk",
   "import.result.seatingCapacity": "{{count}} sitteplasser",
@@ -210,5 +221,10 @@
   "product": "Produkt",
 
   "organisations.select.label": "Velg organisasjon",
-  "organisations.select.noOptions": "Ingen organisasjoner tilgjengelig"
+  "organisations.select.noOptions": "Ingen organisasjoner tilgjengelig",
+  "deckPlan.deactivateConfirmTitle": "Deaktivere setekart?",
+  "deckPlan.deactivateConfirmMessage": "Dette setekartet vil bli deaktivert.",
+  "common.deactivateConfirmTitle": "Deaktivere dette elementet?",
+  "common.deactivateConfirmMessage": "Denne handlingen deaktiverer det valgte elementet. Vil du fortsette?",
+  "common.deactivate": "Deaktiver"
 }

--- a/src/locales/nb/translation.json
+++ b/src/locales/nb/translation.json
@@ -116,7 +116,7 @@
   "vehicleType.saveSuccess": "Kjøretøytype lagret",
   "vehicleType.saveStaleList": "Lagret — men listen kunne ikke oppdateres; den kan være utdatert.",
   "vehicleType.deactivateStaleList": "Deaktivert — men listen kunne ikke oppdateres; den kan være utdatert.",
-  "vehicleTypes.deactivateSuccess": "Kjøretøytype deaktivert",
+  "vehicleType.deactivateSuccess": "Kjøretøytype deaktivert",
   "vehicleType.deactivateConfirmTitle": "Deaktivere kjøretøytype?",
   "vehicleType.deactivateConfirmMessage": "Denne kjøretøytypen vil bli deaktivert.",
   "vehicleType.tab.edit": "Rediger",


### PR DESCRIPTION
Add option to deactivate Vehicle, Vehicle type and Deck plan. "Deactivate" is a "soft delete", meaning the data are not deleted from the database, but they are not visible to the users anymore.

Later we need to figure out in what ways the users need to be able to view deactivated data and if they need to re-activate in some cases