### PR TITLE
Perf nitpicks

### DIFF
--- a/src/data/deck-plans/hooks/useDeckPlans.ts
+++ b/src/data/deck-plans/hooks/useDeckPlans.ts
@@ -81,11 +81,16 @@ export function useDeckPlans() {
     void doFetch().catch(() => {});
   }, [doFetch, filterParam]);
 
-  const handleRequestSort = (property: OrderBy) => {
-    const isAsc = orderBy === property && order === 'asc';
-    setOrder(isAsc ? 'desc' : 'asc');
-    setOrderBy(property);
-  };
+  // Ref-stable so `DataTableHeader` doesn't re-render on every parent render
+  // (#77 N12). Deps are the sort state the toggle reads.
+  const handleRequestSort = useCallback(
+    (property: OrderBy) => {
+      const isAsc = orderBy === property && order === 'asc';
+      setOrder(isAsc ? 'desc' : 'asc');
+      setOrderBy(property);
+    },
+    [order, orderBy]
+  );
 
   const sorted = [...data].sort(compareDeckPlans(orderBy, order));
 

--- a/src/data/vehicle-types/hooks/useVehicleTypes.ts
+++ b/src/data/vehicle-types/hooks/useVehicleTypes.ts
@@ -80,11 +80,16 @@ export function useVehicleTypes() {
     void doFetch().catch(() => {});
   }, [doFetch, filterParam]);
 
-  const handleRequestSort = (property: OrderBy) => {
-    const isAsc = orderBy === property && order === 'asc';
-    setOrder(isAsc ? 'desc' : 'asc');
-    setOrderBy(property);
-  };
+  // Ref-stable so `DataTableHeader` doesn't re-render on every parent render
+  // (#77 N12). Deps are the sort state the toggle reads.
+  const handleRequestSort = useCallback(
+    (property: OrderBy) => {
+      const isAsc = orderBy === property && order === 'asc';
+      setOrder(isAsc ? 'desc' : 'asc');
+      setOrderBy(property);
+    },
+    [order, orderBy]
+  );
 
   const sorted = useMemo(
     () => [...data].sort(compareVehicleTypes(orderBy, order)),

--- a/src/data/vehicles/hooks/useVehicles.ts
+++ b/src/data/vehicles/hooks/useVehicles.ts
@@ -52,11 +52,16 @@ export function useVehicles() {
     doFetch();
   }, [doFetch]);
 
-  const handleRequestSort = (property: VehicleColumnKey) => {
-    const isAsc = orderBy === property && order === 'asc';
-    setOrder(isAsc ? 'desc' : 'asc');
-    setOrderBy(property);
-  };
+  // Ref-stable so `DataTableHeader` doesn't re-render on every parent render
+  // (#77 N12). Deps are the sort state the toggle reads.
+  const handleRequestSort = useCallback(
+    (property: VehicleColumnKey) => {
+      const isAsc = orderBy === property && order === 'asc';
+      setOrder(isAsc ? 'desc' : 'asc');
+      setOrderBy(property);
+    },
+    [order, orderBy]
+  );
 
   // Memoized so that `allData` is a stable reference across renders. The
   // /vehicles URL effect (`useVehicleUrlSelection`) depends on `allData` —

--- a/src/hooks/useResizableSidebar.ts
+++ b/src/hooks/useResizableSidebar.ts
@@ -5,10 +5,12 @@ const MIN_W = 100,
   MAX_W_RATIO = 0.8;
 
 export function useResizableSidebar(
-  initialWidth = 300,
+  initialWidth: number | (() => number) = 300,
   initialCollapsed = false,
   side: Side = 'left'
 ) {
+  // Accepts a lazy initialiser so callers can defer a `window.innerWidth`
+  // read to first mount instead of recomputing it every render (#77 N8).
   const [width, setWidth] = useState<number>(initialWidth);
   const [isResizing, setIsResizing] = useState<boolean>(false);
   const [collapsed, setCollapsed] = useState<boolean>(initialCollapsed);

--- a/src/pages/GenericDataViewPage.tsx
+++ b/src/pages/GenericDataViewPage.tsx
@@ -50,7 +50,7 @@ export default function GenericDataViewPage<T, K extends string>({
 
   const theme = useTheme();
 
-  const initWidth = Math.round(window.innerWidth * DETAILS_PANE_WIDTH_FACTOR);
+  const initWidth = () => Math.round(window.innerWidth * DETAILS_PANE_WIDTH_FACTOR);
   const {
     width: sidebarWidth,
     collapsed: sidebarCollapsed,


### PR DESCRIPTION
Closes #77. Two render-perf nits deferred from PR #74 review.

## Changes
- **Lazy sidebar init-width** — `useResizableSidebar` now accepts `number | (() => number)` (`src/hooks/useResizableSidebar.ts:7`); `GenericDataViewPage.tsx:53` passes `() => Math.round(window.innerWidth * …)`.
- **Memoised sort handlers** — `handleRequestSort` wrapped in `useCallback([order, orderBy])` in all three list hooks: `useVehicles.ts:55`, `useVehicleTypes.ts:83`, `useDeckPlans.ts:84`.

## Gains
- **N8**: `window.innerWidth` was read + `Math.round`'d on *every* render of every list page, only to be discarded — `useState` keeps the first value. Lazy initialiser runs it **once per mount**. Also removes a layout-reflow-triggering `innerWidth` read from the hot render path.
- **N12**: a fresh `handleRequestSort` identity each render busted `DataTableHeader`'s memo, re-rendering the full header (all column cells) on *any* parent render — typing in search, opening the editor, pagination. Now ref-stable except when `order`/`orderBy` actually change, so the header only re-renders on a real sort.

## Verify
- `tsc -b` clean
- `vitest run` — 209/209 pass