### PR TITLE
Fix raw i18n keys leaking in /vehicles compact detail row

### DIFF
--- a/e2e-tests/no-auth/vehicle-compact-detail.spec.ts
+++ b/e2e-tests/no-auth/vehicle-compact-detail.spec.ts
@@ -48,14 +48,24 @@ test.describe('/vehicles compact detail row shows translated labels, not raw i18
     const firstRow = page.locator('table tbody tr').first();
     await expect(firstRow).toBeVisible();
 
-    // The compact leading cell hosts the expand chevron (the only button there).
-    await firstRow.locator('td').first().getByRole('button').click();
+    // Compact-mode precondition: the expand chevron is rendered ONLY in the
+    // compact leading cell (DataTableRow.tsx:58-70). Asserting it visible proves
+    // the container went compact — so the regression check below cannot pass
+    // vacuously off a desktop header that still shows the desktop-only column.
+    const expandBtn = firstRow.locator('td').first().getByRole('button');
+    await expect(expandBtn).toBeVisible();
+    await expandBtn.click();
 
-    const table = page.locator('table');
-    // RED before the fix: the box prints `vehicles.field.operationalNumber` etc.
-    await expect(table).not.toContainText('vehicles.field.');
-    // GREEN signal: the key resolves to its English label (desktop-only column,
-    // so this text exists ONLY in the expanded detail box, not the header).
-    await expect(table).toContainText('Operational Number');
+    // Scope to the overflow detail box (only exists in compact view) so the
+    // assertions can't be satisfied by the desktop header's translated label.
+    const detail = page.getByTestId('mobile-detail-row').first();
+    await expect(detail).toBeVisible();
+
+    // RED before the fix: the box printed `vehicles.field.operationalNumber` etc.
+    // Locale-independent — the raw key is the bug regardless of language.
+    await expect(detail).not.toContainText('vehicles.field.');
+    // GREEN signal: the key resolved to a real label. Browser locale is not
+    // pinned (i18n LanguageDetector, fallback 'en'), so accept en or nb.
+    await expect(detail).toContainText(/Operational Number|Driftsnummer/);
   });
 });

--- a/e2e-tests/no-auth/vehicle-compact-detail.spec.ts
+++ b/e2e-tests/no-auth/vehicle-compact-detail.spec.ts
@@ -1,0 +1,61 @@
+import { test, expect } from '@playwright/test';
+import { interceptVehicleListQuery } from './vehicle-list-helpers';
+import { IS_LIVE, writeConfig, seedAuth, selectFirstOrg } from './live-auth-helpers';
+
+/**
+ * /vehicles compact (narrow-width) overflow row — the expandable detail box must
+ * render TRANSLATED column labels, never raw i18n keys.
+ *
+ * At a container width below COMPACT_VIEW_THRESHOLD (700px) the `desktop-only`
+ * columns (operationalNumber, transportTypeMode, version) drop out of the table
+ * and into a per-row expandable detail box (`MobileDetailRow`). That box printed
+ * `col.headerLabel` verbatim, but the Vehicles config sets `headerLabel` to i18n
+ * KEYS (`vehicles.field.*`) — so the raw keys leaked on screen instead of the
+ * translated text the header row shows via `t(col.headerLabel)`.
+ *
+ * Workflow:
+ *   narrow the viewport (< 700 container) → goto /vehicles → select org → wait
+ *   for rows → click the first row's expand chevron → assert the table shows the
+ *   translated label ("Operational Number") and contains NO `vehicles.field.` key.
+ * Covers:
+ *   - MobileDetailRow runs `headerLabel` through i18next (parity with
+ *     DataTableHeader); no raw key text reaches the user in compact mode.
+ * Modes:
+ *   - mock (E2E_SUITE=no-auth): seedAuth + interceptVehicleListQuery serve the
+ *     15-row fixture; the overflow row is a pure client-render concern.
+ *   - live (E2E_BACKEND=true): same flow against real rows; selectFirstOrg picks
+ *     the org, the fixture intercept is not registered.
+ */
+test.describe('/vehicles compact detail row shows translated labels, not raw i18n keys (no-auth)', () => {
+  test.beforeAll(() => writeConfig());
+
+  test.beforeEach(async ({ page, context }) => {
+    await seedAuth(context);
+    if (!IS_LIVE) await interceptVehicleListQuery(page);
+  });
+
+  test('expanding a row at narrow width renders the i18n-resolved column label', async ({
+    page,
+  }) => {
+    // Below COMPACT_VIEW_THRESHOLD (700) so the table container goes compact and
+    // the desktop-only columns move into the expandable detail box.
+    await page.setViewportSize({ width: 500, height: 900 });
+
+    await page.goto('/vehicles');
+    await selectFirstOrg(page);
+    await page.waitForLoadState('networkidle');
+
+    const firstRow = page.locator('table tbody tr').first();
+    await expect(firstRow).toBeVisible();
+
+    // The compact leading cell hosts the expand chevron (the only button there).
+    await firstRow.locator('td').first().getByRole('button').click();
+
+    const table = page.locator('table');
+    // RED before the fix: the box prints `vehicles.field.operationalNumber` etc.
+    await expect(table).not.toContainText('vehicles.field.');
+    // GREEN signal: the key resolves to its English label (desktop-only column,
+    // so this text exists ONLY in the expanded detail box, not the header).
+    await expect(table).toContainText('Operational Number');
+  });
+});

--- a/src/components/data/MobileDetailRow.tsx
+++ b/src/components/data/MobileDetailRow.tsx
@@ -34,6 +34,7 @@ export default function MobileDetailRow<T, K extends string>({
       <TableCell colSpan={colSpan} sx={{ p: 0, borderBottom: 'none' }}>
         <Collapse in={open} timeout="auto" unmountOnExit>
           <Box
+            data-testid="mobile-detail-row"
             sx={{
               m: 2,
               ml: { xs: 2, sm: 7 },

--- a/src/components/data/MobileDetailRow.tsx
+++ b/src/components/data/MobileDetailRow.tsx
@@ -1,4 +1,5 @@
 import { TableRow, TableCell, Collapse, Box, Typography } from '@mui/material';
+import { useTranslation } from 'react-i18next';
 import type { ColumnDefinition } from './dataTableTypes.ts';
 
 interface Props<T, K extends string> {
@@ -20,6 +21,10 @@ export default function MobileDetailRow<T, K extends string>({
   columns,
   handleColumnEvent,
 }: Props<T, K>) {
+  // `headerLabel` may be an i18n key or a bare string — resolve it the same way
+  // DataTableHeader does, so compact-view labels are translated, not raw keys.
+  const { t } = useTranslation();
+
   if (columns.length === 0) {
     return null;
   }
@@ -40,7 +45,7 @@ export default function MobileDetailRow<T, K extends string>({
             {columns.map(col => (
               <Box key={col.id}>
                 <Typography variant="subtitle2" component="div" gutterBottom>
-                  <strong>{col.headerLabel}</strong>
+                  <strong>{t(col.headerLabel, col.headerLabel)}</strong>
                 </Typography>
                 <Box>
                   {col.renderCell(


### PR DESCRIPTION
Narrow-width `/vehicles` rows printed raw i18n keys (`vehicles.field.operationalNumber`, `…parentTransportMode`, `…version`) in the expandable detail box instead of translated labels.

## Cause
`MobileDetailRow.tsx:43` rendered `col.headerLabel` verbatim. The Vehicles config sets `headerLabel` to i18n keys (`vehicleViewConfig.tsx:41,62,69`), and unlike `DataTableHeader.tsx:47` the detail row never ran them through `t()`. Only surfaces below `COMPACT_VIEW_THRESHOLD` (700px) where `desktop-only` columns move into the overflow row.

## Changes
- `src/components/data/MobileDetailRow.tsx` — `t(col.headerLabel, col.headerLabel)`, parity with `DataTableHeader`. Bare-string fallback keeps vehicle-types/deck-plans unchanged.
- `e2e-tests/no-auth/vehicle-compact-detail.spec.ts` — narrow-viewport guard: expand row → assert no `vehicles.field.` leak + translated label visible. Dual-mode (mock + live).

## Verification
- New spec: RED before fix (raw keys present), GREEN after.
- `tsc -b` clean; `vitest run` no new failures (5 pre-existing Storybook failures on `main`, unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)