### PR TITLE
chore: sync vendored Sobek schema snapshot

### DIFF
--- a/src/graphql/sobek.schema.graphqls
+++ b/src/graphql/sobek.schema.graphqls
@@ -146,11 +146,11 @@ type Page {
 # KeyValues type
 type KeyValues {
     key: String!
-    values: [String!]!
+    value: String!
 }
 input KeyValuesInput {
     key: String!
-    values: [String!]!
+    value: String!
 }
 
 # PrivateCode type
@@ -190,6 +190,7 @@ input PassengerCapacityInput {
 
 # DeckPlan type
 type DeckPlan {
+    dataOwnerRef: String!
     netexId: String!
     name: MultilingualString
     description: MultilingualString
@@ -227,6 +228,7 @@ type OrganisationPage {
 
 # Vehicle
 type Vehicle {
+    dataOwnerRef: String!
     netexId: String!
     name: MultilingualString
     description: MultilingualString
@@ -263,6 +265,7 @@ type VehiclePage {
 }
 
 type VehicleType {
+    dataOwnerRef: String!
     netexId: String!
     name: MultilingualString
     shortName: MultilingualString


### PR DESCRIPTION
Refresh `src/graphql/sobek.schema.graphqls` from canonical (`https://entur.github.io/sobek/schema.graphqls`).

## Changes
- `KeyValues`/`KeyValuesInput`: `values: [String!]!` → `value: String!` *(breaking upstream; unused by hathor)*
- `dataOwnerRef: String!` added to `DeckPlan`/`Vehicle`/`VehicleType` output types *(additive)*

## Impact
None on hathor: no query under `src/graphql/vehicles/**` selects `keyValues`, and no field hathor selects was removed/renamed. Reference-only snapshot (not codegen-wired) → no build/type impact.

## Verification
`curl -s https://entur.github.io/sobek/schema.graphqls | diff src/graphql/sobek.schema.graphqls -` → clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)