### PR TITLE
fix(stories): supply org + auth context to Home and Menu stories

### DIFF
--- a/src/auth/mockAuth.tsx
+++ b/src/auth/mockAuth.tsx
@@ -1,0 +1,31 @@
+import type { Decorator } from '@storybook/react-vite';
+import { AuthContext, type AuthContextProps } from 'react-oidc-context';
+
+// Only the fields hathor's useAuth() reads; cast because AuthContextProps
+// carries the full oidc-client-ts surface a story never exercises.
+const SIGNED_IN = {
+  isLoading: false,
+  isAuthenticated: true,
+  user: {
+    access_token: 'story-token',
+    profile: { sub: 'story-user', name: 'Story User' },
+  },
+  signinRedirect: () => Promise.resolve(),
+  signoutRedirect: () => Promise.resolve(),
+} as unknown as AuthContextProps;
+
+/**
+ * Decorator supplying a signed-in OIDC context to a story. Without it
+ * react-oidc-context yields undefined, so useAuth() reports isAuthenticated
+ * false and auth-gated branches render their logged-out state.
+ *
+ * @param over - context fields overriding the signed-in default.
+ * @returns a decorator wrapping the story in the mocked auth context.
+ */
+export const withAuth =
+  (over: Partial<AuthContextProps> = {}): Decorator =>
+  Story => (
+    <AuthContext.Provider value={{ ...SIGNED_IN, ...over }}>
+      <Story />
+    </AuthContext.Provider>
+  );

--- a/src/components/Menu.stories.tsx
+++ b/src/components/Menu.stories.tsx
@@ -3,6 +3,7 @@ import { useEffect } from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import Menu from './Menu';
 import { NavRailProvider, useNavRail } from '../contexts/NavRailContext';
+import { withOrganisations } from '../contexts/mockOrganisations.tsx';
 
 /**
  * Drives the desktop rail to a fixed expanded/collapsed state for a story.
@@ -41,6 +42,8 @@ const meta: Meta<typeof Menu> = {
     },
   },
   decorators: [
+    // Menu reads currentOrganisation; the real provider needs config/OIDC/fetch.
+    withOrganisations(),
     // initialEntries seeds an active route so one item renders `selected`.
     Story => (
       <MemoryRouter initialEntries={['/vehicle-types']}>

--- a/src/contexts/mockOrganisations.tsx
+++ b/src/contexts/mockOrganisations.tsx
@@ -1,0 +1,37 @@
+import type { Decorator } from '@storybook/react-vite';
+import type { Organisation } from '../data/organisations/types/organisationTypes.ts';
+import { OrganisationsContext, type OrganisationsContextType } from './useOrganisationsContext.ts';
+
+// NeTEx ids in full `Codespace:Type:Number` form, matching what Sobek returns.
+const ORGS: Organisation[] = [
+  { id: 'NMR:Organisation:1', name: { value: 'First Org' }, type: 'AUTHORITY' },
+  { id: 'NMR:Organisation:2', name: { value: 'Second Org' }, type: 'OPERATOR' },
+];
+
+const SIGNED_IN: OrganisationsContextType = {
+  data: ORGS,
+  currentOrganisation: ORGS[0],
+  setCurrentOrganisation: () => {},
+  error: null,
+  loading: false,
+  refetch: () => Promise.resolve(),
+};
+
+/**
+ * Decorator supplying a static OrganisationsContext to a story. The real
+ * OrganisationsProvider derives its value from runtime config, OIDC and a
+ * fetch, none of which exist in Storybook — so org-aware components (Menu,
+ * Home) throw without this.
+ *
+ * @param over - context fields overriding the signed-in-with-two-orgs default.
+ * @returns a decorator wrapping the story in the mocked provider.
+ */
+export const withOrganisations =
+  (over: Partial<OrganisationsContextType> = {}): Decorator =>
+  Story => (
+    <OrganisationsContext.Provider value={{ ...SIGNED_IN, ...over }}>
+      <Story />
+    </OrganisationsContext.Provider>
+  );
+
+export { ORGS as mockOrganisations };

--- a/src/pages/Home.stories.tsx
+++ b/src/pages/Home.stories.tsx
@@ -1,10 +1,16 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { MemoryRouter } from 'react-router-dom';
 import HomePage from './Home';
+import { withOrganisations } from '../contexts/mockOrganisations.tsx';
+import { withAuth } from '../auth/mockAuth.tsx';
 
 /**
  * Stories for the Home dashboard. A MemoryRouter decorator supplies the routing
- * context the page's <Link>s need; `fullscreen` layout lets the flat, full-width
+ * context the page's <Link>s need; `withOrganisations` and `withAuth` stand in
+ * for the real OrganisationsProvider and OIDC provider (config/fetch-driven, so
+ * unavailable here) that gate the org sections and the logged-out band —
+ * together they put the page in its signed-in, org-selected state.
+ * `fullscreen` layout lets the flat, full-width
  * dashboard breathe without Storybook's default padding. Domain glyphs come from
  * the nav-rail MenuIcon sprite, mounted globally in `.storybook/preview.tsx`.
  */
@@ -21,6 +27,8 @@ const meta: Meta<typeof HomePage> = {
     },
   },
   decorators: [
+    withAuth(),
+    withOrganisations(),
     Story => (
       <MemoryRouter>
         <Story />


### PR DESCRIPTION
`useOrganisationsContext` throws outside a provider, leaving `test:stories` red — 2 files / 5 tests. Stories now get static context mocks; the real `OrganisationsProvider` needs config + OIDC + a fetch.

## Changes

- `src/contexts/mockOrganisations.tsx` — new `withOrganisations(over?)` decorator. Real provider at `src/contexts/OrganisationsContext.tsx:33`; consumers `src/components/Menu.tsx:124`, `src/pages/Home.tsx:124`. Org ids match `e2e-tests/organisation-persistence.spec.ts:4`.
- `src/auth/mockAuth.tsx` — new `withAuth(over?)` decorator over `react-oidc-context`'s `AuthContext`. Without it `isAuthenticated` is false, so `src/pages/Home.tsx:266` rendered a "You need to log in" band under a populated dashboard (sections gate on `currentOrganisation`, `src/pages/Home.tsx:197`/`:223`).
- `src/pages/Home.stories.tsx:27`, `src/components/Menu.stories.tsx:52` — decorators applied.

## Verification

`npm run test:stories` 9 files / 34 tests pass (was 2 files / 5 tests failing) · `npm run test` 28/174 · `tsc -b` exit 0 · `npm run check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)